### PR TITLE
Resolved svelte warnings

### DIFF
--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -7,7 +7,7 @@
 
 	let { mouseState, class: classes }: { mouseState: number; class: string } = $props();
 
-	const twClasses = cn(classes);
+	const twClasses = $derived(cn(classes));
 
 	// Define constants
 	const viewboxSize = 100;

--- a/src/lib/components/addCourse/LinkCourseDataTable.svelte
+++ b/src/lib/components/addCourse/LinkCourseDataTable.svelte
@@ -42,7 +42,9 @@
 		get data() {
 			return data;
 		},
-		columns,
+		get columns() {
+			return columns;
+		},
 		state: {
 			get pagination() {
 				return pagination;

--- a/src/lib/components/addCourse/LinkCourses.svelte
+++ b/src/lib/components/addCourse/LinkCourses.svelte
@@ -32,6 +32,7 @@
 			.map((i) => courses[i])
 	);
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(linkCoursesForm, {
 		id: 'link-courses-form',
 		validators: zodClient(linkingCoursesSchema),

--- a/src/lib/components/addCourse/NewCourseForm.svelte
+++ b/src/lib/components/addCourse/NewCourseForm.svelte
@@ -17,6 +17,7 @@
 	let { createNewCourseForm, program, dialogOpen = $bindable() }: Props = $props();
 	const id = useId();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(createNewCourseForm, {
 		validators: zodClient(newCourseSchema),
 		id: `new-course-${id}`,

--- a/src/lib/components/graphSettings/CreateGraph.svelte
+++ b/src/lib/components/graphSettings/CreateGraph.svelte
@@ -24,6 +24,7 @@
 
 	let { parentType, parentId, newGraphForm }: CreateNewGraphButtonProps = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(newGraphForm, {
 		validators: zodClient(newGraphSchema),
 		onResult: ({ result }) => {

--- a/src/lib/components/graphSettings/CreateLink.svelte
+++ b/src/lib/components/graphSettings/CreateLink.svelte
@@ -24,9 +24,12 @@
 
 	let { graph, newLinkForm }: CreateNewGraphButtonProps = $props();
 
-	const parentType = graph.parentType;
-	const parentId = (graph.parentType == 'COURSE' ? graph.courseId : graph.sandboxId) as number;
+	const parentType = $derived(graph.parentType);
+	const parentId = $derived(
+		(graph.parentType == 'COURSE' ? graph.courseId : graph.sandboxId) as number
+	);
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(newLinkForm, {
 		validators: zodClient(newLinkSchema),
 		onResult: ({ result }) => {

--- a/src/lib/components/graphSettings/DeleteGraph.svelte
+++ b/src/lib/components/graphSettings/DeleteGraph.svelte
@@ -23,9 +23,10 @@
 	const { graph, editGraphForm, onSuccess = () => {} }: GraphLinksProps = $props();
 
 	const id = $props.id();
-	const parentType = graph.parentType;
-	const parentId = (parentType === 'COURSE' ? graph.courseId : graph.sandboxId) as number;
+	const parentType = $derived(graph.parentType);
+	const parentId = $derived((parentType === 'COURSE' ? graph.courseId : graph.sandboxId) as number);
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(editGraphForm, {
 		id: 'delete-graph-' + id,
 		validators: zodClient(graphSchemaWithId),

--- a/src/lib/components/graphSettings/DeleteLink.svelte
+++ b/src/lib/components/graphSettings/DeleteLink.svelte
@@ -26,9 +26,12 @@
 	const { graph, link, editLinkForm, onSuccess = () => {} }: GraphLinksProps = $props();
 
 	const id = $props.id();
-	const parentType = graph.parentType;
-	const parentId = (graph.parentType === 'COURSE' ? graph.courseId : graph.sandboxId) as number;
+	const parentType = $derived(graph.parentType);
+	const parentId = $derived(
+		(graph.parentType === 'COURSE' ? graph.courseId : graph.sandboxId) as number
+	);
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(editLinkForm, {
 		id: 'delete-graph-link-' + id,
 		validators: zodClient(editLinkSchema),

--- a/src/lib/components/graphSettings/DuplicateGraph.svelte
+++ b/src/lib/components/graphSettings/DuplicateGraph.svelte
@@ -58,6 +58,7 @@
 	}
 
 	const triggerId = useId();
+	// svelte-ignore state_referenced_locally
 	const form = superForm(duplicateGraphForm, {
 		id: 'duplicate-graph-' + useId(),
 		validators: zodClient(duplicateGraphSchema),

--- a/src/lib/components/graphSettings/GraphSettings.svelte
+++ b/src/lib/components/graphSettings/GraphSettings.svelte
@@ -25,11 +25,12 @@
 	const { graph, canDelete, editGraphForm }: GraphLinksProps = $props();
 
 	const id = $props.id();
-	const parentType = graph.parentType;
-	const parentId = (parentType === 'COURSE' ? graph.courseId : graph.sandboxId) as number;
+	const parentType = $derived(graph.parentType);
+	const parentId = $derived((parentType === 'COURSE' ? graph.courseId : graph.sandboxId) as number);
 
 	let graphSettingsOpen = $state(false);
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(editGraphForm, {
 		id: 'change-graph-' + id,
 		validators: zodClient(graphSchemaWithId),

--- a/src/routes/graph-editor/courses/[courseCode]/+page.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/+page.svelte
@@ -17,15 +17,17 @@
 
 	let { data }: { data: PageData } = $props();
 
-	const hasAtLeastEditPermission =
+	const hasAtLeastEditPermission = $derived(
 		data.user != undefined &&
-		data.course != undefined &&
-		hasCoursePermissions(data.user, data.course, 'CourseAdminEditorORProgramAdminEditor');
+			data.course != undefined &&
+			hasCoursePermissions(data.user, data.course, 'CourseAdminEditorORProgramAdminEditor')
+	);
 
-	const hasAtLeastAdminPermission =
+	const hasAtLeastAdminPermission = $derived(
 		data.user != undefined &&
-		data.course != undefined &&
-		hasCoursePermissions(data.user, data.course, 'CourseAdminORProgramAdminEditor');
+			data.course != undefined &&
+			hasCoursePermissions(data.user, data.course, 'CourseAdminORProgramAdminEditor')
+	);
 </script>
 
 <article class="my-6 mb-12 space-y-6">

--- a/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/settings/+page.svelte
@@ -14,8 +14,10 @@
 	let { data }: { data: PageData } = $props();
 
 	let editCourseDialogOpen = $state(false);
-	let programsYouCanEdit = data.course.programs.filter((program) =>
-		hasProgramPermissions(data.user, program, 'ProgramAdminEditor')
+	let programsYouCanEdit = $derived(
+		data.course.programs.filter((program) =>
+			hasProgramPermissions(data.user, program, 'ProgramAdminEditor')
+		)
 	);
 </script>
 

--- a/src/routes/graph-editor/courses/[courseCode]/settings/EditCourseName.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/settings/EditCourseName.svelte
@@ -14,6 +14,7 @@
 
 	let { course, editCourseForm, onSuccess }: EditCourseNameProps = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(editCourseForm, {
 		validators: zodClient(newCourseSchema),
 		id: `edit-course-name`,

--- a/src/routes/graph-editor/courses/[courseCode]/settings/superUsers/ChangeRoleForm.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/settings/superUsers/ChangeRoleForm.svelte
@@ -25,6 +25,7 @@
 		onSuccess = () => {}
 	}: ChangeRoleProps = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm((page.data as PageData).editSuperUserForm, {
 		id: 'editSuperUserForm' + userId + '-' + newRole,
 		validators: zodClient(editSuperUserSchema),

--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/+page.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/+page.svelte
@@ -26,6 +26,7 @@
 	// This is a workaround for the fact that we can't use $derived due to the reordering.
 	// A writable $derived would not be re-proxied on reassignment, so mutations like
 	// `graph.domains = ...` or `domain.style = ...` below would stop being reactive.
+	// svelte-ignore state_referenced_locally
 	// eslint-disable-next-line svelte/prefer-writable-derived
 	let graph = $state(data.graph);
 	$effect(() => {

--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomain.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomain.svelte
@@ -37,6 +37,7 @@
 	let changeDomainDialog = $state(false);
 	let domainStyleOpen = $state(false);
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm((page.data as PageData).newDomainForm, {
 		id: 'change-domain-form-' + useId() + domain.id,
 		validators: zodClient(domainSchema),

--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomainRel.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomainRel.svelte
@@ -22,6 +22,7 @@
 
 	const { graph, domain, sourceDomain, targetDomain, type }: Props = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm((page.data as PageData).changeDomainRelForm, {
 		id: `change-${type}-rel-form-${useId()}`,
 		validators: zodClient(changeDomainRelSchema),

--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/DeleteDomain.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/DeleteDomain.svelte
@@ -19,6 +19,7 @@
 	const connectedSubjects = $derived(graph.subjects.filter((s) => s.domainId == domain.id));
 	const relationCount = $derived(domain.sourceDomains.length + domain.targetDomains.length);
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm((page.data as PageData).deleteDomainForm, {
 		id: 'delete-domain-form-' + domain.id,
 		validators: zodClient(deleteDomainSchema),

--- a/src/routes/graph-editor/graphs/[graphid=int]/lectures/+page.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/lectures/+page.svelte
@@ -25,6 +25,7 @@
 	// This is a workaround for the fact that we can't use $derived due to the reordering from the
 	// svelte-dnd-action library. A writable $derived would not be re-proxied on reassignment, so
 	// mutations like `lecture.order = index` below would stop being reactive.
+	// svelte-ignore state_referenced_locally
 	// eslint-disable-next-line svelte/prefer-writable-derived
 	let lectures = $state(data.graph.lectures);
 	$effect(() => {

--- a/src/routes/graph-editor/graphs/[graphid=int]/lectures/AddSubjectToLecture.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/lectures/AddSubjectToLecture.svelte
@@ -22,6 +22,7 @@
 	const { lecture, graph }: Props = $props();
 
 	let dialogOpen = $state(false);
+	// svelte-ignore state_referenced_locally
 	let subjectsLinked: string[] = $state(lecture.subjects.map((s) => s.id.toString()));
 
 	const form = superForm((page.data as PageData).newLectureForm, {

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/+page.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/+page.svelte
@@ -23,6 +23,7 @@
 	// This is a workaround for the fact that we can't use $derived due to the reordering.
 	// A writable $derived would not be re-proxied on reassignment, so mutations like
 	// `graph.subjects = ...` below would stop being reactive.
+	// svelte-ignore state_referenced_locally
 	// eslint-disable-next-line svelte/prefer-writable-derived
 	let graph = $state(data.graph);
 	$effect(() => {

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubject.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubject.svelte
@@ -35,6 +35,7 @@
 	let domainIdOpen = $state(false);
 
 	const triggerId = useId();
+	// svelte-ignore state_referenced_locally
 	const form = superForm((page.data as PageData).newSubjectForm, {
 		id: 'change-subject-form-' + useId() + '-' + subject.id,
 		validators: zodClient(subjectSchema),

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubjectInGraph.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubjectInGraph.svelte
@@ -21,6 +21,7 @@
 
 	let { subject, graph, domain, onSuccess }: Props = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm((page.data as PageData).newSubjectForm, {
 		id: 'change-domain-form-1-' + useId() + (domain?.id ?? 'none'),
 		validators: zodClient(subjectSchema),

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubjectRel.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubjectRel.svelte
@@ -22,6 +22,7 @@
 
 	const { graph, subject, sourceSubject, targetSubject, type }: Props = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm((page.data as PageData).changeSubjectRelForm, {
 		id: `change-${type}-rel-form-${useId()}`,
 		validators: zodClient(changeSubjectRelSchema),

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/DeleteSubject.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/DeleteSubject.svelte
@@ -18,6 +18,7 @@
 
 	const relationCount = $derived(subject.sourceSubjects.length + subject.targetSubjects.length);
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm((page.data as PageData).deleteSubjectForm, {
 		id: 'delete-subject-form-' + subject.id,
 		validators: zodClient(deleteSubjectSchema),

--- a/src/routes/graph-editor/newCourseButton.svelte
+++ b/src/routes/graph-editor/newCourseButton.svelte
@@ -30,6 +30,7 @@
 		errorMessage = 'You do not have the permissions to create a new course'
 	}: Props = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(courseForm, {
 		id: useId(),
 		validators: zodClient(newCourseSchema),

--- a/src/routes/graph-editor/programs/[programId=int]/settings/EditProgramName.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/EditProgramName.svelte
@@ -14,6 +14,7 @@
 
 	let { program, editProgramForm, onSuccess }: EditProgramNameProps = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(editProgramForm, {
 		validators: zodClient(editProgramSchema),
 		id: 'edit-program-name',

--- a/src/routes/graph-editor/programs/[programId=int]/settings/courses/CoursesTable.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/courses/CoursesTable.svelte
@@ -42,7 +42,9 @@
 		get data() {
 			return data;
 		},
-		columns,
+		get columns() {
+			return columns;
+		},
 		state: {
 			get pagination() {
 				return pagination;

--- a/src/routes/graph-editor/programs/[programId=int]/settings/superUsers/AddSuperUser.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/superUsers/AddSuperUser.svelte
@@ -31,6 +31,7 @@
 
 	let { program, allUsers, editSuperUserForm }: AddNewUserProps = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(editSuperUserForm, {
 		id: 'add-super-user-' + useId(),
 		validators: zodClient(editSuperUserSchema),

--- a/src/routes/graph-editor/programs/[programId=int]/settings/superUsers/ChangeRoleForm.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/superUsers/ChangeRoleForm.svelte
@@ -36,6 +36,7 @@
 		onSuccess = () => {}
 	}: ChangeRoleProps = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(editSuperUserForm, {
 		id: 'edit-super-user-' + useId(),
 		validators: zodClient(editSuperUserSchema),

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/+page.svelte
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/+page.svelte
@@ -17,15 +17,17 @@
 
 	let { data }: { data: PageData } = $props();
 
-	const hasAtLeastEditPermission =
+	const hasAtLeastEditPermission = $derived(
 		data.user != undefined &&
-		data.sandbox != undefined &&
-		hasSandboxPermissions(data.user, data.sandbox, 'OwnerOREditor');
+			data.sandbox != undefined &&
+			hasSandboxPermissions(data.user, data.sandbox, 'OwnerOREditor')
+	);
 
-	const hasAtLeastAdminPermission =
+	const hasAtLeastAdminPermission = $derived(
 		data.user != undefined &&
-		data.sandbox != undefined &&
-		hasSandboxPermissions(data.user, data.sandbox, 'Owner');
+			data.sandbox != undefined &&
+			hasSandboxPermissions(data.user, data.sandbox, 'Owner')
+	);
 </script>
 
 <article class="my-6 mb-12 space-y-6">

--- a/src/routes/graph-editor/sandboxes/newSandboxButton.svelte
+++ b/src/routes/graph-editor/sandboxes/newSandboxButton.svelte
@@ -19,6 +19,7 @@
 
 	const { newSandboxForm }: Props = $props();
 
+	// svelte-ignore state_referenced_locally
 	const form = superForm(newSandboxForm, {
 		id: useId(),
 		validators: zodClient(newSandboxSchema),


### PR DESCRIPTION
This PR introduces changes to resolve the Svelte (pnpm check) warnings.

- It adds svelte-ignore state_referenced_locally for superforms
- Adds missing $derived
- Changes columns to a getter in course data table