### PR TITLE
fix: AddCourses list updates after linking courses (#81)

### DIFF
--- a/src/lib/components/addCourse/AddCourse.svelte
+++ b/src/lib/components/addCourse/AddCourse.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import DialogButton from '$lib/components/DialogButton.svelte';
 	import { hasProgramPermissions } from '$lib/utils/permissions';
-	import { onMount } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import LinkCourseDataTable from './LinkCourseDataTable.svelte';
 	import NewCourseForm from './NewCourseForm.svelte';
@@ -23,19 +22,17 @@
 	let { user, program, courses, linkCoursesForm, createNewCourseForm }: AddCourseProps = $props();
 
 	let loading = $state(true);
-	let data: Course[] = $state([]);
+	let allCourses: Course[] = $state([]);
 	let dialogOpen = $state(false);
 
 	const hasAdminRights = $derived(hasProgramPermissions(user, program, 'ProgramAdmin'));
 
-	onMount(() => {
+	// Re-await whenever the streamed promise changes (e.g. after invalidateAll on link)
+	$effect(() => {
+		loading = true;
 		courses
-			.then((courses) => {
-				// Data is all the courses that are not already linked to the program
-				data = courses.filter((c) => {
-					return !program.courses.some((course) => c.code === course.code);
-				});
-
+			.then((resolved) => {
+				allCourses = resolved;
 				loading = false;
 			})
 			.catch(() => {
@@ -43,6 +40,12 @@
 				toast.error('Failed to load courses');
 			});
 	});
+
+	// Linkable courses = all courses not already linked to the program. Derived so it
+	// recomputes when program.courses updates after a link.
+	const data = $derived(
+		allCourses.filter((c) => !program.courses.some((course) => c.code === course.code))
+	);
 </script>
 
 <DialogButton


### PR DESCRIPTION
## Problem

Fixes #81. After linking courses to a program, reopening the AddCourses menu still listed the freshly linked courses as linkable options.

## Root cause

`AddCourse.svelte` built the linkable-courses list (`data`) once inside `onMount`. Linking triggers superForm's `invalidateAll`, which reruns the load and refreshes `program.courses`, but the one-shot `onMount` filter never re-ran, so `data` stayed frozen at the first-open snapshot. The streamed `courses` promise also became a new reference on invalidate, which `onMount` ignored.

## Fix

- `$effect` re-awaits the `courses` promise whenever its reference changes.
- `data` is now `$derived`, recomputing when either the resolved courses or `program.courses` change.

Only `src/lib/components/addCourse/AddCourse.svelte` changed.

## Verification

- `pnpm check`: 0 errors on the changed file.
- `pnpm lint`: prettier passes; no new eslint issues.