### PR TITLE
fix: bound height of Command popover comboboxes (searchbar for add super user)

### DIFF
--- a/src/lib/components/SelectUsers.svelte
+++ b/src/lib/components/SelectUsers.svelte
@@ -51,29 +51,31 @@
 	<Popover.Content>
 		<Command.Root loop>
 			<Command.Input autofocus placeholder="Search users..." class="my-1 h-9" />
-			<Command.Empty>No user found.</Command.Empty>
-			<Command.Group>
-				{#each users as user (user.id)}
-					<Command.Item
-						value={user.email + ' ' + user.nickname || user.firstName + ' ' + user.lastName || ''}
-						onSelect={() => {
-							closeAndFocusTrigger(id, () => (isSuperUserPopoverOpen = false));
-							value = user.id;
-							onSelect(user);
-						}}
-						class="flex items-center justify-between"
-					>
-						{displayName(user)}
+			<Command.List>
+				<Command.Empty>No user found.</Command.Empty>
+				<Command.Group>
+					{#each users as user (user.id)}
+						<Command.Item
+							value={user.email + ' ' + user.nickname || user.firstName + ' ' + user.lastName || ''}
+							onSelect={() => {
+								closeAndFocusTrigger(id, () => (isSuperUserPopoverOpen = false));
+								value = user.id;
+								onSelect(user);
+							}}
+							class="flex items-center justify-between"
+						>
+							{displayName(user)}
 
-						<div class="flex items-center gap-1">
-							{#if userRoles.has(user.id)}
-								<p class="ml-auto text-xs">Program {userRoles.get(user.id)}</p>
-							{/if}
-							<Check class={cn('ml-auto w-auto', user.id !== value && 'w-0 text-transparent')} />
-						</div>
-					</Command.Item>
-				{/each}
-			</Command.Group>
+							<div class="flex items-center gap-1">
+								{#if userRoles.has(user.id)}
+									<p class="ml-auto text-xs">Program {userRoles.get(user.id)}</p>
+								{/if}
+								<Check class={cn('ml-auto w-auto', user.id !== value && 'w-0 text-transparent')} />
+							</div>
+						</Command.Item>
+					{/each}
+				</Command.Group>
+			</Command.List>
 		</Command.Root>
 	</Popover.Content>
 </Popover.Root>

--- a/src/lib/components/graphSettings/DuplicateGraph.svelte
+++ b/src/lib/components/graphSettings/DuplicateGraph.svelte
@@ -217,52 +217,54 @@
 			<Popover.Content>
 				<Command.Root loop>
 					<Command.Input autofocus placeholder="Search destinations..." class="my-1 h-9" />
-					<Command.Empty>No course found.</Command.Empty>
-					<Command.Group heading="Sandboxes">
-						{#each destinationSandboxes as sandbox (sandbox.id)}
-							<Command.Item
-								value={sandbox.name}
-								onSelect={() => {
-									$formData.destinationId = sandbox.id;
-									$formData.destinationType = 'SANDBOX';
-									closeAndFocusTrigger(triggerId, () => (isDestinationCourseOpen = false));
-								}}
-							>
-								{sandbox.name}
-								<Check
-									class={cn(
-										'ml-auto',
-										($formData.destinationType !== 'SANDBOX' ||
-											$formData.destinationId !== sandbox.id) &&
-											'text-transparent'
-									)}
-								/>
-							</Command.Item>
-						{/each}
-					</Command.Group>
+					<Command.List>
+						<Command.Empty>No course found.</Command.Empty>
+						<Command.Group heading="Sandboxes">
+							{#each destinationSandboxes as sandbox (sandbox.id)}
+								<Command.Item
+									value={sandbox.name}
+									onSelect={() => {
+										$formData.destinationId = sandbox.id;
+										$formData.destinationType = 'SANDBOX';
+										closeAndFocusTrigger(triggerId, () => (isDestinationCourseOpen = false));
+									}}
+								>
+									{sandbox.name}
+									<Check
+										class={cn(
+											'ml-auto',
+											($formData.destinationType !== 'SANDBOX' ||
+												$formData.destinationId !== sandbox.id) &&
+												'text-transparent'
+										)}
+									/>
+								</Command.Item>
+							{/each}
+						</Command.Group>
 
-					<Command.Group heading="Courses">
-						{#each destinationCourses as course (course.id)}
-							<Command.Item
-								value={course.name}
-								onSelect={() => {
-									$formData.destinationId = course.id;
-									$formData.destinationType = 'COURSE';
-									closeAndFocusTrigger(triggerId, () => (isDestinationCourseOpen = false));
-								}}
-							>
-								{course.name}
-								<Check
-									class={cn(
-										'ml-auto',
-										($formData.destinationType !== 'COURSE' ||
-											$formData.destinationId !== course.id) &&
-											'text-transparent'
-									)}
-								/>
-							</Command.Item>
-						{/each}
-					</Command.Group>
+						<Command.Group heading="Courses">
+							{#each destinationCourses as course (course.id)}
+								<Command.Item
+									value={course.name}
+									onSelect={() => {
+										$formData.destinationId = course.id;
+										$formData.destinationType = 'COURSE';
+										closeAndFocusTrigger(triggerId, () => (isDestinationCourseOpen = false));
+									}}
+								>
+									{course.name}
+									<Check
+										class={cn(
+											'ml-auto',
+											($formData.destinationType !== 'COURSE' ||
+												$formData.destinationId !== course.id) &&
+												'text-transparent'
+										)}
+									/>
+								</Command.Item>
+							{/each}
+						</Command.Group>
+					</Command.List>
 				</Command.Root>
 			</Popover.Content>
 		</Popover.Root>

--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/DomainRelField.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/DomainRelField.svelte
@@ -60,23 +60,25 @@
 		<Popover.Content>
 			<Command.Root>
 				<Command.Input autofocus placeholder="Search domains..." class="h-9" />
-				<Command.Empty>No domain found.</Command.Empty>
-				<Command.Group>
-					{#each domains as domain (domain.id)}
-						<Command.Item
-							value={domain.id.toString()}
-							onSelect={() => {
-								$formData[id] = domain.id;
-								closeAndFocusTrigger(triggerId);
-							}}
-						>
-							{domain.name}
-							<Check class={cn('ml-auto', domain.id !== $formData[id] && 'text-transparent')} />
-						</Command.Item>
-					{:else}
-						<p>No domain found.</p>
-					{/each}
-				</Command.Group>
+				<Command.List>
+					<Command.Empty>No domain found.</Command.Empty>
+					<Command.Group>
+						{#each domains as domain (domain.id)}
+							<Command.Item
+								value={domain.id.toString()}
+								onSelect={() => {
+									$formData[id] = domain.id;
+									closeAndFocusTrigger(triggerId);
+								}}
+							>
+								{domain.name}
+								<Check class={cn('ml-auto', domain.id !== $formData[id] && 'text-transparent')} />
+							</Command.Item>
+						{:else}
+							<p>No domain found.</p>
+						{/each}
+					</Command.Group>
+				</Command.List>
 			</Command.Root>
 		</Popover.Content>
 	</Popover.Root>

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubject.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubject.svelte
@@ -161,23 +161,25 @@
 				<Popover.Content>
 					<Command.Root>
 						<Command.Input autofocus placeholder="Search domain..." class="h-9" />
-						<Command.Empty>No domain found.</Command.Empty>
-						<Command.Group>
-							{#each graph.domains as domain (domain.id)}
-								<Command.Item
-									value={domain.id.toString()}
-									onSelect={() => {
-										$formData.domainId = domain.id;
-										closeAndFocusTrigger(triggerId, () => (domainIdOpen = false));
-									}}
-								>
-									{domain.name}
-									<Check
-										class={cn('ml-auto', domain.id !== $formData.domainId && 'text-transparent')}
-									/>
-								</Command.Item>
-							{/each}
-						</Command.Group>
+						<Command.List>
+							<Command.Empty>No domain found.</Command.Empty>
+							<Command.Group>
+								{#each graph.domains as domain (domain.id)}
+									<Command.Item
+										value={domain.id.toString()}
+										onSelect={() => {
+											$formData.domainId = domain.id;
+											closeAndFocusTrigger(triggerId, () => (domainIdOpen = false));
+										}}
+									>
+										{domain.name}
+										<Check
+											class={cn('ml-auto', domain.id !== $formData.domainId && 'text-transparent')}
+										/>
+									</Command.Item>
+								{/each}
+							</Command.Group>
+						</Command.List>
 					</Command.Root>
 				</Popover.Content>
 			</Popover.Root>

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/CreateNewSubject.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/CreateNewSubject.svelte
@@ -91,23 +91,25 @@
 				<Popover.Content>
 					<Command.Root>
 						<Command.Input autofocus placeholder="Search domain..." class="h-9" />
-						<Command.Empty>No domain found.</Command.Empty>
-						<Command.Group>
-							{#each graph.domains as domain (domain.id)}
-								<Command.Item
-									value={domain.id.toString()}
-									onSelect={() => {
-										$formData.domainId = domain.id;
-										closeAndFocusTrigger(triggerId, () => (domainIdOpen = false));
-									}}
-								>
-									{domain.name}
-									<Check
-										class={cn('ml-auto', domain.id !== $formData.domainId && 'text-transparent')}
-									/>
-								</Command.Item>
-							{/each}
-						</Command.Group>
+						<Command.List>
+							<Command.Empty>No domain found.</Command.Empty>
+							<Command.Group>
+								{#each graph.domains as domain (domain.id)}
+									<Command.Item
+										value={domain.id.toString()}
+										onSelect={() => {
+											$formData.domainId = domain.id;
+											closeAndFocusTrigger(triggerId, () => (domainIdOpen = false));
+										}}
+									>
+										{domain.name}
+										<Check
+											class={cn('ml-auto', domain.id !== $formData.domainId && 'text-transparent')}
+										/>
+									</Command.Item>
+								{/each}
+							</Command.Group>
+						</Command.List>
 					</Command.Root>
 				</Popover.Content>
 			</Popover.Root>

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/SubjectRelField.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/SubjectRelField.svelte
@@ -60,23 +60,25 @@
 		<Popover.Content>
 			<Command.Root>
 				<Command.Input autofocus placeholder="Search subjects..." class="h-9" />
-				<Command.Empty>No subject found.</Command.Empty>
-				<Command.Group>
-					{#each subjects as subject (subject.id)}
-						<Command.Item
-							value={subject.id.toString()}
-							onSelect={() => {
-								$formData[id] = subject.id;
-								closeAndFocusTrigger(triggerId);
-							}}
-						>
-							{subject.name}
-							<Check class={cn('ml-auto', subject.id !== $formData[id] && 'text-transparent')} />
-						</Command.Item>
-					{:else}
-						<p>No subject found.</p>
-					{/each}
-				</Command.Group>
+				<Command.List>
+					<Command.Empty>No subject found.</Command.Empty>
+					<Command.Group>
+						{#each subjects as subject (subject.id)}
+							<Command.Item
+								value={subject.id.toString()}
+								onSelect={() => {
+									$formData[id] = subject.id;
+									closeAndFocusTrigger(triggerId);
+								}}
+							>
+								{subject.name}
+								<Check class={cn('ml-auto', subject.id !== $formData[id] && 'text-transparent')} />
+							</Command.Item>
+						{:else}
+							<p>No subject found.</p>
+						{/each}
+					</Command.Group>
+				</Command.List>
 			</Command.Root>
 		</Popover.Content>
 	</Popover.Root>


### PR DESCRIPTION
## What

Issue #95 reported the "Add super user" selector as an ugly, broken-looking dropdown: a long flat list of names with no visible search box.

Root cause (per triage brief): several Command-based popover comboboxes wrapped their items in a `Command.Group` without a `Command.List` container. With many items the popover has no max height, grows to fit them all, and the layout engine shoves it (and its search input) out of the viewport.

## Change

Wrap `Command.Empty` + `Command.Group` in `Command.List` (default `max-h-[300px]`, scrolls internally) in every affected combobox, matching the course search popover that already used the correct pattern.

Affected:
- `SelectUsers.svelte` (both Add super user dialogs, course + program)
- `DuplicateGraph.svelte` (destination picker)
- `DomainRelField.svelte`, `SubjectRelField.svelte` (relation pickers)
- `ChangeSubject.svelte`, `CreateNewSubject.svelte` (domain pickers)

Filtering/search behavior unchanged; no user fetching/filtering changes.

## Checks

- `pnpm check`: 0 errors
- `pnpm lint`: passes (one pre-existing unrelated warning in `NewCourseForm.svelte`)

Closes #95