### PR TITLE
fix: breadcrumbs show entity names, not raw URL path (#66)

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -4,7 +4,9 @@ declare global {
 	namespace App {
 		// interface Error {}
 		// interface Locals {}
-		// interface PageData {}
+		interface PageData {
+			breadcrumbs?: import('$lib/utils/breadcrumbs').Breadcrumb[];
+		}
 		// interface PageState {}
 		// interface Platform {}
 	}

--- a/src/lib/components/NavigationBar.svelte
+++ b/src/lib/components/NavigationBar.svelte
@@ -1,24 +1,37 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import type { ResolvedPathname } from '$app/types';
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
+	import type { Breadcrumb as Crumb } from '$lib/utils/breadcrumbs';
 
 	let mouseState: number = $state(-1); // eslint-disable-line @typescript-eslint/no-unused-vars
 	let clearState: ReturnType<typeof setTimeout> | undefined = undefined;
 
-	// The breadcrumb trail is built from arbitrary segments of the current path, so the
-	// destination isn't a statically resolvable route - it's always a slice of the already
-	// resolved current pathname.
-	let urls = $derived.by(() => {
+	// URL-encoded segments (spaces, non-ASCII) should read as their decoded name. A malformed
+	// escape sequence would throw, so fall back to the raw segment in that case.
+	function safeDecode(segment: string): string {
+		try {
+			return decodeURIComponent(segment);
+		} catch {
+			return segment;
+		}
+	}
+
+	// A route that knows its own entities supplies a `breadcrumbs` trail through page data
+	// (see src/lib/utils/breadcrumbs.ts). When it does, we trust it. Otherwise we fall back
+	// to building the trail from the raw path segments, which can only title-case each part.
+	let urls = $derived.by<Crumb[]>(() => {
+		if (page.data?.breadcrumbs) return page.data.breadcrumbs;
+
 		const parts = page.url?.pathname?.split('/') ?? [];
-		let result: { name: string; url: ResolvedPathname }[] = [];
+		let result: Crumb[] = [];
 
 		return parts.reduce((acc, part, index) => {
 			if (part === '') return acc;
 
-			const url = ('/' + parts.slice(1, index + 1).join('/')) as ResolvedPathname;
-			const name = part.charAt(0).toUpperCase() + part.slice(1);
+			const url = '/' + parts.slice(1, index + 1).join('/');
+			const decoded = safeDecode(part);
+			const name = decoded.charAt(0).toUpperCase() + decoded.slice(1);
 
 			if (!isNaN(Number(name))) {
 				if (acc[acc.length - 1]?.url.includes('courses')) {
@@ -90,6 +103,7 @@
 							</DropdownMenu.Trigger>
 							<DropdownMenu.Content align="start">
 								{#each urls.slice(1, urls.length - 2) as { name, url } (url)}
+									<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- breadcrumb urls are already-resolved runtime paths -->
 									<a href={url}>
 										<DropdownMenu.Item>
 											{name}

--- a/src/lib/components/NavigationBar.svelte
+++ b/src/lib/components/NavigationBar.svelte
@@ -93,7 +93,20 @@
 						<Breadcrumb.Item class="sm:text-md text-sm">
 							<Breadcrumb.Page>{urls[2].name}</Breadcrumb.Page>
 						</Breadcrumb.Item>
-					{:else if urls.length > 3}
+					{:else if urls.length == 4}
+						<Breadcrumb.Separator />
+						<Breadcrumb.Item class="sm:text-md text-sm">
+							<Breadcrumb.Link href={urls[1].url}>{urls[1].name}</Breadcrumb.Link>
+						</Breadcrumb.Item>
+						<Breadcrumb.Separator />
+						<Breadcrumb.Item class="text-xs sm:text-base">
+							<Breadcrumb.Link href={urls[2].url}>{urls[2].name}</Breadcrumb.Link>
+						</Breadcrumb.Item>
+						<Breadcrumb.Separator />
+						<Breadcrumb.Item class="text-xs sm:text-base">
+							<Breadcrumb.Page>{urls[3].name}</Breadcrumb.Page>
+						</Breadcrumb.Item>
+					{:else if urls.length > 4}
 						<Breadcrumb.Separator />
 
 						<DropdownMenu.Root>

--- a/src/lib/components/NavigationBar.svelte
+++ b/src/lib/components/NavigationBar.svelte
@@ -47,6 +47,17 @@
 		}, result);
 	});
 
+	// Show Home plus up to 4 more crumbs uncollapsed. Beyond that, collapse the
+	// middle into an ellipsis dropdown and keep only the last 4 visible.
+	const MAX_VISIBLE_TAIL = 4;
+
+	let hidden = $derived(
+		urls.length > MAX_VISIBLE_TAIL + 1 ? urls.slice(1, urls.length - MAX_VISIBLE_TAIL) : []
+	);
+	let tail = $derived(
+		urls.length > MAX_VISIBLE_TAIL + 1 ? urls.slice(-MAX_VISIBLE_TAIL) : urls.slice(1)
+	);
+
 	function handleNavClick() {
 		mouseState = Math.random();
 
@@ -79,34 +90,7 @@
 						</Breadcrumb.Item>
 					{/if}
 
-					{#if urls.length == 2}
-						<Breadcrumb.Separator />
-						<Breadcrumb.Item class="sm:text-md text-sm">
-							<Breadcrumb.Page>{urls[1].name}</Breadcrumb.Page>
-						</Breadcrumb.Item>
-					{:else if urls.length == 3}
-						<Breadcrumb.Separator />
-						<Breadcrumb.Item class="sm:text-md text-sm">
-							<Breadcrumb.Link href={urls[1].url}>{urls[1].name}</Breadcrumb.Link>
-						</Breadcrumb.Item>
-						<Breadcrumb.Separator />
-						<Breadcrumb.Item class="sm:text-md text-sm">
-							<Breadcrumb.Page>{urls[2].name}</Breadcrumb.Page>
-						</Breadcrumb.Item>
-					{:else if urls.length == 4}
-						<Breadcrumb.Separator />
-						<Breadcrumb.Item class="sm:text-md text-sm">
-							<Breadcrumb.Link href={urls[1].url}>{urls[1].name}</Breadcrumb.Link>
-						</Breadcrumb.Item>
-						<Breadcrumb.Separator />
-						<Breadcrumb.Item class="text-xs sm:text-base">
-							<Breadcrumb.Link href={urls[2].url}>{urls[2].name}</Breadcrumb.Link>
-						</Breadcrumb.Item>
-						<Breadcrumb.Separator />
-						<Breadcrumb.Item class="text-xs sm:text-base">
-							<Breadcrumb.Page>{urls[3].name}</Breadcrumb.Page>
-						</Breadcrumb.Item>
-					{:else if urls.length > 4}
+					{#if hidden.length > 0}
 						<Breadcrumb.Separator />
 
 						<DropdownMenu.Root>
@@ -115,7 +99,7 @@
 								<span class="sr-only">Toggle menu</span>
 							</DropdownMenu.Trigger>
 							<DropdownMenu.Content align="start">
-								{#each urls.slice(1, urls.length - 2) as { name, url } (url)}
+								{#each hidden as { name, url } (url)}
 									<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- breadcrumb urls are already-resolved runtime paths -->
 									<a href={url}>
 										<DropdownMenu.Item>
@@ -125,16 +109,18 @@
 								{/each}
 							</DropdownMenu.Content>
 						</DropdownMenu.Root>
-
-						<Breadcrumb.Separator />
-						<Breadcrumb.Item class="text-xs sm:text-base">
-							<Breadcrumb.Link href={urls.at(-2)!.url}>{urls.at(-2)!.name}</Breadcrumb.Link>
-						</Breadcrumb.Item>
-						<Breadcrumb.Separator />
-						<Breadcrumb.Item class="text-xs sm:text-base">
-							<Breadcrumb.Page>{urls.at(-1)!.name}</Breadcrumb.Page>
-						</Breadcrumb.Item>
 					{/if}
+
+					{#each tail as { name, url }, index (url)}
+						<Breadcrumb.Separator />
+						<Breadcrumb.Item class="text-xs sm:text-base">
+							{#if index == tail.length - 1}
+								<Breadcrumb.Page>{name}</Breadcrumb.Page>
+							{:else}
+								<Breadcrumb.Link href={url}>{name}</Breadcrumb.Link>
+							{/if}
+						</Breadcrumb.Item>
+					{/each}
 				</Breadcrumb.List>
 			</Breadcrumb.Root>
 		</div>

--- a/src/lib/utils/breadcrumbs.ts
+++ b/src/lib/utils/breadcrumbs.ts
@@ -1,0 +1,4 @@
+// A single breadcrumb node. Loads can return a `breadcrumbs` array in their page
+// data to give the navigation bar the real entity names for the current route,
+// instead of letting it guess from the raw URL path.
+export type Breadcrumb = { name: string; url: string };

--- a/src/routes/graph-editor/graphs/[graphid=int]/+layout.server.ts
+++ b/src/routes/graph-editor/graphs/[graphid=int]/+layout.server.ts
@@ -1,9 +1,16 @@
 import prisma from '$lib/server/db/prisma';
 import { GraphValidator } from '$lib/validators/graphValidator';
+import type { Breadcrumb } from '$lib/utils/breadcrumbs';
 import { error } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ params }) => {
+const leafLabels: Record<string, string> = {
+	domains: 'Domains',
+	subjects: 'Subjects',
+	lectures: 'Lectures'
+};
+
+export const load: LayoutServerLoad = async ({ params, url }) => {
 	if (!params.graphid) {
 		error(400, { message: 'Graph ID is required' });
 	}
@@ -20,6 +27,8 @@ export const load: LayoutServerLoad = async ({ params }) => {
 				id: graphId
 			},
 			include: {
+				course: { select: { code: true } },
+				sandbox: { select: { id: true, name: true } },
 				domains: {
 					include: {
 						sourceDomains: true,
@@ -55,10 +64,34 @@ export const load: LayoutServerLoad = async ({ params }) => {
 		const graphValidator = new GraphValidator(graph);
 		const issues = graphValidator.validate();
 
+		// Build the breadcrumb trail from the graph's real parent (course or sandbox) and the
+		// active leaf tab, so the nav bar shows names instead of guessing from the URL path.
+		const breadcrumbs: Breadcrumb[] = [{ name: 'Home', url: '/graph-editor' }];
+		if (graph.parentType === 'COURSE' && graph.course) {
+			breadcrumbs.push({ name: 'Courses', url: '/graph-editor/courses' });
+			breadcrumbs.push({
+				name: graph.course.code,
+				url: `/graph-editor/courses/${graph.course.code}`
+			});
+		} else if (graph.sandbox) {
+			breadcrumbs.push({ name: 'Sandboxes', url: '/graph-editor/sandboxes' });
+			breadcrumbs.push({
+				name: graph.sandbox.name,
+				url: `/graph-editor/sandboxes/${graph.sandbox.id}`
+			});
+		}
+		breadcrumbs.push({ name: graph.name, url: `/graph-editor/graphs/${graph.id}` });
+
+		const leaf = url.pathname.split('/').filter(Boolean).at(-1);
+		if (leaf && leaf in leafLabels) {
+			breadcrumbs.push({ name: leafLabels[leaf], url: `/graph-editor/graphs/${graph.id}/${leaf}` });
+		}
+
 		// Happy path
 		return {
 			graph: graph,
-			issues: issues
+			issues: issues,
+			breadcrumbs
 		};
 	} catch (e: unknown) {
 		error(500, { message: e instanceof Error ? e.message : `${e}` });

--- a/src/routes/graph-editor/programs/[programId=int]/settings/+page.server.ts
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/+page.server.ts
@@ -44,6 +44,12 @@ export const load = (async ({ params, locals }) => {
 		if (!dbProgram) throw Error('You do not have permissions to access this program setting page');
 
 		return {
+			breadcrumbs: [
+				{ name: 'Home', url: '/graph-editor' },
+				{ name: 'Programs', url: '/graph-editor/programs' },
+				{ name: dbProgram.name, url: `/graph-editor/programs/${programId}/settings` },
+				{ name: 'Settings', url: `/graph-editor/programs/${programId}/settings` }
+			],
 			program: dbProgram,
 			user,
 			allUsers,

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/+page.server.ts
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/+page.server.ts
@@ -74,6 +74,11 @@ export const load = (async ({ params, locals }) => {
 		});
 
 		return {
+			breadcrumbs: [
+				{ name: 'Home', url: '/graph-editor' },
+				{ name: 'Sandboxes', url: '/graph-editor/sandboxes' },
+				{ name: dbSandbox.name, url: `/graph-editor/sandboxes/${dbSandbox.id}` }
+			],
 			user,
 			sandbox: dbSandbox,
 			graphs: dbSandbox.graphs,
@@ -90,6 +95,10 @@ export const load = (async ({ params, locals }) => {
 		};
 	} catch (e: unknown) {
 		return {
+			breadcrumbs: [
+				{ name: 'Home', url: '/graph-editor' },
+				{ name: 'Sandboxes', url: '/graph-editor/sandboxes' }
+			],
 			user,
 			sandbox: undefined,
 			graphs: [],

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/+page.server.ts
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/+page.server.ts
@@ -49,6 +49,12 @@ export const load = (async ({ params, locals }) => {
 		const allUsers = await prisma.user.findMany();
 
 		return {
+			breadcrumbs: [
+				{ name: 'Home', url: '/graph-editor' },
+				{ name: 'Sandboxes', url: '/graph-editor/sandboxes' },
+				{ name: dbSandbox.name, url: `/graph-editor/sandboxes/${dbSandbox.id}` },
+				{ name: 'Settings', url: `/graph-editor/sandboxes/${dbSandbox.id}/settings` }
+			],
 			sandbox: dbSandbox,
 			user,
 			allUsers,


### PR DESCRIPTION
Fixes #66.

## Problem

The breadcrumb trail was built entirely from the current URL's path segments, title-casing each raw segment with no access to the loaded entities. That produced:

- Program settings: `home > programs > program [id] > settings` (raw id)
- Sandbox settings: `home > sandboxes > settings` (sandbox segment silently dropped)
- Graph editor: `home > graphs > domains/subjects/lectures` (course and graph dropped)
- Names with spaces or non-ASCII shown percent-encoded (e.g. `Hello%20w%C3%A9rld`)

## Fix

Routes that know their own entities now return a `breadcrumbs` trail in their page data. `NavigationBar` prefers it over the URL-derived fallback.

- Program settings: `home > programs > [program name] > settings`
- Sandbox settings: `home > sandboxes > [sandbox name] > settings`
- Graph editor: `home > courses > [course code] > [graph name] > domains/subjects/lectures`
  - Sandbox-owned graphs use `home > sandboxes > [sandbox name] > [graph name] > ...` so that route keeps working too.

The URL fallback (all other routes) now decodes each segment before display, so encoded names render correctly there as well.

## Changes

- `src/lib/utils/breadcrumbs.ts` — shared `Breadcrumb` type
- `src/app.d.ts` — `PageData.breadcrumbs`
- `src/lib/components/NavigationBar.svelte` — prefer page-data trail, safe-decode fallback
- program settings, sandbox settings loads — supply their trail
- graph `+layout.server.ts` — fetch the parent course/sandbox and build the trail from the active leaf tab

## Verification

- `pnpm check`: 0 errors on changed files (pre-existing warnings unchanged)
- `pnpm lint`: passes
- `pnpm format`: clean
