### PR TITLE
Fix: http 500 when signing out with SurfConext

### DIFF
--- a/src/routes/auth/signout/+page.server.ts
+++ b/src/routes/auth/signout/+page.server.ts
@@ -9,7 +9,7 @@ export const actions: Actions = {
 				path: '/'
 			});
 		} else {
-			signOut(event);
+			return signOut(event);
 		}
 	}
 };


### PR DESCRIPTION
This MR adds a `return` to the signout. This is required by Auth.js. This change should remove the 500 response when signing out from a SurfConext account.