### PR TITLE
Let sandbox editors leave a sandbox

### DIFF
--- a/src/lib/server/actions/Sandboxes.ts
+++ b/src/lib/server/actions/Sandboxes.ts
@@ -8,6 +8,7 @@ import type {
 	deleteSandboxSchema,
 	editSandboxSchema,
 	editSuperUserSchema,
+	leaveSandboxSchema,
 	newSandboxSchema
 } from '$lib/zod/sandboxSchema';
 import { redirect } from '@sveltejs/kit';
@@ -196,6 +197,38 @@ export class SandboxActions {
 			});
 		} catch {
 			return setError(form, '', "You don't have permission to delete this sandbox");
+		}
+
+		throw redirect(303, '/');
+	}
+
+	/**
+	 * Remove the acting user as an editor of a sandbox, then redirect them to the home page
+	 * since they no longer have access to this sandbox's page.
+	 *
+	 * PERMISSIONS
+	 * - Any user who is an EDITOR (not owner) of the sandbox can remove themselves
+	 *
+	 * @param user - The user performing the action, must be an editor of the sandbox
+	 * @param form - Validated form data with the sandboxId to leave
+	 * @returns Never returns normally: on success it throws a redirect to `/`. On invalid input
+	 * or missing permission, returns the form with an error via setError instead of throwing.
+	 */
+	static async leaveSandbox(user: User, form: SuperValidated<Infer<typeof leaveSandboxSchema>>) {
+		if (!form.valid) return setError(form, '', 'Form is not valid');
+
+		try {
+			await prisma.sandbox.update({
+				where: {
+					id: form.data.sandboxId,
+					editors: { some: { id: user.id } }
+				},
+				data: {
+					editors: { disconnect: { id: user.id } }
+				}
+			});
+		} catch {
+			return setError(form, '', "You don't have permission to leave this sandbox");
 		}
 
 		throw redirect(303, '/');

--- a/src/lib/zod/sandboxSchema.ts
+++ b/src/lib/zod/sandboxSchema.ts
@@ -23,3 +23,7 @@ export const editSuperUserSchema = z.object({
 	userId: z.string(),
 	role: z.enum(['owner', 'editor', 'revoke'])
 });
+
+export const leaveSandboxSchema = z.object({
+	sandboxId: z.number()
+});

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/+page.server.ts
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/+page.server.ts
@@ -1,6 +1,7 @@
 import prisma from '$lib/server/db/prisma';
 import { error } from '@sveltejs/kit';
 import { GraphActions } from '$lib/server/actions';
+import { SandboxActions } from '$lib/server/actions/Sandboxes';
 import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import { superValidate } from 'sveltekit-superforms';
 import { getUser } from '$lib/server/actions/Users.js';
@@ -8,6 +9,7 @@ import { duplicateGraphSchema, graphSchemaWithId, newGraphSchema } from '$lib/zo
 import { whereHasCoursePermission, whereHasSandboxPermission } from '$lib/server/permissions';
 import { LinkActions } from '$lib/server/actions/Links';
 import { editLinkSchema, newLinkSchema } from '$lib/zod/linkSchema';
+import { leaveSandboxSchema } from '$lib/zod/sandboxSchema';
 
 import type { Actions } from '@sveltejs/kit';
 import type { ServerLoad } from '@sveltejs/kit';
@@ -91,6 +93,7 @@ export const load = (async ({ params, locals }) => {
 			newLinkForm: await superValidate(zod(newLinkSchema)),
 			editLinkForm: await superValidate(zod(editLinkSchema)),
 			deleteLinkForm: await superValidate(zod(editLinkSchema)),
+			leaveSandboxForm: await superValidate(zod(leaveSandboxSchema)),
 			error: undefined
 		};
 	} catch (e: unknown) {
@@ -111,6 +114,7 @@ export const load = (async ({ params, locals }) => {
 			deleteLinkForm: await superValidate(zod(editLinkSchema)),
 			newLinkForm: await superValidate(zod(newLinkSchema)),
 			editLinkForm: await superValidate(zod(editLinkSchema)),
+			leaveSandboxForm: await superValidate(zod(leaveSandboxSchema)),
 			error: e instanceof Error ? e.message : `${e}`
 		};
 	}
@@ -144,5 +148,9 @@ export const actions: Actions = {
 	'delete-link': async (event) => {
 		const form = await superValidate(event, zod(editLinkSchema));
 		return LinkActions.deleteLink(await getUser(event), form);
+	},
+	'leave-sandbox': async (event) => {
+		const form = await superValidate(event, zod(leaveSandboxSchema));
+		return SandboxActions.leaveSandbox(await getUser(event), form);
 	}
 };

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/+page.svelte
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/+page.svelte
@@ -7,6 +7,7 @@
 	import CreateGraph from '$lib/components/graphSettings/CreateGraph.svelte';
 	import DuplicateGraph from '$lib/components/graphSettings/DuplicateGraph.svelte';
 	import GraphSettings from '$lib/components/graphSettings/GraphSettings.svelte';
+	import LeaveSandbox from './LeaveSandbox.svelte';
 
 	// Icons
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
@@ -51,6 +52,8 @@
 							sandboxId: String(data.sandbox.id)
 						})}>Settings <ArrowRight /></Button
 					>
+				{:else if hasAtLeastEditPermission}
+					<LeaveSandbox sandbox={data.sandbox} />
 				{/if}
 			</div>
 

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/LeaveSandbox.svelte
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/LeaveSandbox.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+
+	// Components
+	import { buttonVariants } from '$lib/components/ui/button';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+
+	// Icons
+	import { LogOut } from '@lucide/svelte';
+
+	// Types
+	import type { Sandbox } from '@prisma/client';
+
+	type LeaveSandboxProps = {
+		sandbox: Sandbox;
+	};
+
+	let { sandbox }: LeaveSandboxProps = $props();
+</script>
+
+<AlertDialog.Root>
+	<AlertDialog.Trigger class={buttonVariants({ variant: 'destructive' })}>
+		<LogOut /> Leave Sandbox
+	</AlertDialog.Trigger>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Are you sure you want to leave?</AlertDialog.Title>
+			<AlertDialog.Description>
+				You will lose editor access to this sandbox. An existing editor or the owner will need to
+				add you back if you want access again.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			<form action="?/leave-sandbox" method="POST" use:enhance>
+				<input type="hidden" name="sandboxId" value={sandbox.id} />
+				<AlertDialog.Action type="submit" class={buttonVariants({ variant: 'destructive' })}>
+					Leave anyway
+				</AlertDialog.Action>
+			</form>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/DeleteSandbox.svelte
+++ b/src/routes/graph-editor/sandboxes/[sandboxId=int]/settings/DeleteSandbox.svelte
@@ -5,6 +5,7 @@
 	// Components
 	import { buttonVariants } from '$lib/components/ui/button';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 
 	// Icons
 	import { Trash2 } from '@lucide/svelte';
@@ -13,9 +14,12 @@
 	import type { PageData } from './$types';
 
 	const data = page.data as PageData;
+
+	let confirmName = $state('');
+	const nameMatches = $derived(confirmName === data.sandbox.name);
 </script>
 
-<AlertDialog.Root>
+<AlertDialog.Root onOpenChange={(open) => !open && (confirmName = '')}>
 	<AlertDialog.Trigger class={buttonVariants({ variant: 'destructive' })}>
 		<Trash2 /> Delete Sandbox
 	</AlertDialog.Trigger>
@@ -24,14 +28,19 @@
 			<AlertDialog.Title>Are you absolutely sure?</AlertDialog.Title>
 			<AlertDialog.Description>
 				This action cannot be undone. This will permanently delete this sandbox, its graphs and
-				links.
+				links. Type <b>{data.sandbox.name}</b> to confirm.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
+		<Input bind:value={confirmName} placeholder={data.sandbox.name} autocomplete="off" />
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
 			<form action="?/delete-sandbox" method="POST" use:enhance>
 				<input type="hidden" name="sandboxId" value={data.sandbox.id} />
-				<AlertDialog.Action type="submit" class={buttonVariants({ variant: 'destructive' })}>
+				<AlertDialog.Action
+					type="submit"
+					disabled={!nameMatches}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
 					Delete anyway
 				</AlertDialog.Action>
 			</form>


### PR DESCRIPTION
## Summary
- Adds `SandboxActions.leaveSandbox`, a new server action gated on the acting user being an editor of the sandbox (not the owner), which removes them as editor and redirects to home.
- Adds `leaveSandboxSchema` and wires a `leave-sandbox` form action into the main sandbox page (`+page.server.ts`), not the owner-only settings page.
- Adds a `LeaveSandbox.svelte` component with a confirmation dialog, shown on the main sandbox page for users who are editors but not the owner.

Closes #79