### PR TITLE
Require typing name to confirm course/program deletion

### DIFF
--- a/src/routes/graph-editor/courses/[courseCode]/settings/DeleteCourse.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/settings/DeleteCourse.svelte
@@ -4,6 +4,7 @@
 	// Components
 	import { buttonVariants } from '$lib/components/ui/button';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 
 	// Icons
 	import { Trash2 } from '@lucide/svelte';
@@ -13,9 +14,12 @@
 
 	type Props = { course: Course };
 	let { course }: Props = $props();
+
+	let confirmName = $state('');
+	const nameMatches = $derived(confirmName === course.name);
 </script>
 
-<AlertDialog.Root>
+<AlertDialog.Root onOpenChange={(open) => !open && (confirmName = '')}>
 	<AlertDialog.Trigger class={buttonVariants({ variant: 'destructive' })}>
 		<Trash2 /> Delete Course
 	</AlertDialog.Trigger>
@@ -24,14 +28,19 @@
 			<AlertDialog.Title>Are you absolutely sure?</AlertDialog.Title>
 			<AlertDialog.Description>
 				This action cannot be undone. This will permanently delete this course, its graphs and
-				links. Embeds for this course will stop working.
+				links. Embeds for this course will stop working. Type <b>{course.name}</b> to confirm.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
+		<Input bind:value={confirmName} placeholder={course.name} autocomplete="off" />
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
 			<form action="?/delete-course" method="POST" use:enhance>
 				<input type="hidden" name="courseId" value={course.id} />
-				<AlertDialog.Action type="submit" class={buttonVariants({ variant: 'destructive' })}>
+				<AlertDialog.Action
+					type="submit"
+					disabled={!nameMatches}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
 					Delete anyway
 				</AlertDialog.Action>
 			</form>

--- a/src/routes/graph-editor/programs/[programId=int]/settings/DeleteProgram.svelte
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/DeleteProgram.svelte
@@ -4,6 +4,7 @@
 	// Components
 	import { buttonVariants } from '$lib/components/ui/button';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 
 	// Icons
 	import { Trash2 } from '@lucide/svelte';
@@ -13,9 +14,12 @@
 
 	type Props = { program: Program };
 	let { program }: Props = $props();
+
+	let confirmName = $state('');
+	const nameMatches = $derived(confirmName === program.name);
 </script>
 
-<AlertDialog.Root>
+<AlertDialog.Root onOpenChange={(open) => !open && (confirmName = '')}>
 	<AlertDialog.Trigger class={buttonVariants({ variant: 'destructive' })}>
 		<Trash2 /> Delete Program
 	</AlertDialog.Trigger>
@@ -25,14 +29,20 @@
 			<AlertDialog.Description>
 				This action cannot be undone. Courses assigned to this program will be unlinked, but <b
 					>not</b
-				> deleted.
+				>
+				deleted. Type <b>{program.name}</b> to confirm.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
+		<Input bind:value={confirmName} placeholder={program.name} autocomplete="off" />
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
 			<form action="?/delete-program" method="POST" use:enhance>
 				<input type="hidden" name="programId" value={program.id} />
-				<AlertDialog.Action type="submit" class={buttonVariants({ variant: 'destructive' })}>
+				<AlertDialog.Action
+					type="submit"
+					disabled={!nameMatches}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
 					Delete anyway
 				</AlertDialog.Action>
 			</form>


### PR DESCRIPTION
## Summary
- Delete Course and Delete Program dialogs now require typing the exact course/program name before the destructive action button enables, matching the confirmation pattern added for Delete Sandbox.
- Graph deletion left as is per request.
