### PR TITLE
fix: allow duplicate urls in breadcrumbs

### DIFF
--- a/src/lib/components/NavigationBar.svelte
+++ b/src/lib/components/NavigationBar.svelte
@@ -99,7 +99,7 @@
 								<span class="sr-only">Toggle menu</span>
 							</DropdownMenu.Trigger>
 							<DropdownMenu.Content align="start">
-								{#each hidden as { name, url } (url)}
+								{#each hidden as { name, url }, index (`${url}:${index}`)}
 									<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- breadcrumb urls are already-resolved runtime paths -->
 									<a href={url}>
 										<DropdownMenu.Item>
@@ -111,7 +111,7 @@
 						</DropdownMenu.Root>
 					{/if}
 
-					{#each tail as { name, url }, index (url)}
+					{#each tail as { name, url }, index (`${url}:${index}`)}
 						<Breadcrumb.Separator />
 						<Breadcrumb.Item class="text-xs sm:text-base">
 							{#if index == tail.length - 1}

--- a/src/routes/graph-editor/programs/[programId=int]/settings/+page.server.ts
+++ b/src/routes/graph-editor/programs/[programId=int]/settings/+page.server.ts
@@ -47,7 +47,7 @@ export const load = (async ({ params, locals }) => {
 			breadcrumbs: [
 				{ name: 'Home', url: '/graph-editor' },
 				{ name: 'Programs', url: '/graph-editor/programs' },
-				{ name: dbProgram.name, url: `/graph-editor/programs/${programId}/settings` },
+				{ name: dbProgram.name },
 				{ name: 'Settings', url: `/graph-editor/programs/${programId}/settings` }
 			],
 			program: dbProgram,


### PR DESCRIPTION
This PR fixes an issue introduced by the breadcrumbs in programme. Previously, duplicate urls would make the svelte each block have duplicate keys.