### PR TITLE
Add tooltips to icon-only buttons

### DIFF
--- a/src/lib/components/GraphDecorators.svelte
+++ b/src/lib/components/GraphDecorators.svelte
@@ -21,6 +21,7 @@
 	import screenfull from 'screenfull';
 	import { fade } from 'svelte/transition';
 	import { Button, buttonVariants } from './ui/button';
+	import * as Tooltip from './ui/tooltip';
 	import { cn } from '$lib/utils';
 	import { graphState } from '$lib/d3/GraphD3State.svelte';
 	import { page } from '$app/state';
@@ -176,33 +177,57 @@
 	class="absolute right-1 bottom-1 flex flex-col gap-1"
 	transition:fade={{ duration: settings.GRAPH_ANIMATION_DURATION }}
 >
-	{#if !graphView.isLectures()}
-		<Button
-			class="size-8 rounded-xl"
-			onclick={() => {
-				graphD3.centerOnGraph();
-			}}
-			size="icon"
-		>
-			<SearchSlash />
-		</Button>
-		<Button class="size-8 rounded-xl" onclick={() => graphD3.zoomIn()} size="icon">
-			<ZoomIn />
-		</Button>
-		<Button class="size-8 rounded-xl" onclick={() => graphD3.zoomOut()} size="icon">
-			<ZoomOut />
-		</Button>
-	{/if}
+	<Tooltip.Provider>
+		{#if !graphView.isLectures()}
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					class={cn(buttonVariants({ size: 'icon' }), 'size-8 rounded-xl')}
+					onclick={() => {
+						graphD3.centerOnGraph();
+					}}
+				>
+					<SearchSlash />
+				</Tooltip.Trigger>
+				<Tooltip.Content><p>Center graph</p></Tooltip.Content>
+			</Tooltip.Root>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					class={cn(buttonVariants({ size: 'icon' }), 'size-8 rounded-xl')}
+					onclick={() => graphD3.zoomIn()}
+				>
+					<ZoomIn />
+				</Tooltip.Trigger>
+				<Tooltip.Content><p>Zoom in</p></Tooltip.Content>
+			</Tooltip.Root>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					class={cn(buttonVariants({ size: 'icon' }), 'size-8 rounded-xl')}
+					onclick={() => graphD3.zoomOut()}
+				>
+					<ZoomOut />
+				</Tooltip.Trigger>
+				<Tooltip.Content><p>Zoom out</p></Tooltip.Content>
+			</Tooltip.Root>
+		{/if}
 
-	{#if screenfull.isEnabled && document}
-		<Button class="size-8 rounded-xl" onclick={toggleFullscreen}>
-			{#if isFullscreen}
-				<Minimize class="h-5 w-5" />
-			{:else}
-				<Maximize class="h-5 w-5" />
-			{/if}
-		</Button>
-	{/if}
+		{#if screenfull.isEnabled && document}
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					class={cn(buttonVariants(), 'size-8 rounded-xl')}
+					onclick={toggleFullscreen}
+				>
+					{#if isFullscreen}
+						<Minimize class="h-5 w-5" />
+					{:else}
+						<Maximize class="h-5 w-5" />
+					{/if}
+				</Tooltip.Trigger>
+				<Tooltip.Content
+					><p>{isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}</p></Tooltip.Content
+				>
+			</Tooltip.Root>
+		{/if}
+	</Tooltip.Provider>
 </div>
 
 <!-- AutoLayout buttons -->

--- a/src/lib/components/ui/grid/ReorderRows.svelte
+++ b/src/lib/components/ui/grid/ReorderRows.svelte
@@ -4,6 +4,7 @@
 	import type { Snippet } from 'svelte';
 	import { dragHandle, dragHandleZone } from 'svelte-dnd-action';
 	import { Cell, Rows } from '.';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 
 	type Props = {
 		class?: string;
@@ -33,13 +34,23 @@
 	<Rows {items} {name}>
 		{#snippet children(domain, index)}
 			<Cell class="p-0">
-				<div
-					class="m-2 rounded bg-purple-200 p-2 transition-colors hover:bg-purple-400"
-					use:dragHandle
-					aria-label="drag-handle for {domain.id}"
-				>
-					<MoveVertical class="h-4 w-4" />
-				</div>
+				<Tooltip.Provider>
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<div
+									{...props}
+									class="m-2 rounded bg-purple-200 p-2 transition-colors hover:bg-purple-400"
+									use:dragHandle
+									aria-label="drag-handle for {domain.id}"
+								>
+									<MoveVertical class="h-4 w-4" />
+								</div>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content><p>Drag to reorder</p></Tooltip.Content>
+					</Tooltip.Root>
+				</Tooltip.Provider>
 			</Cell>
 
 			{@render resizeChildren(domain, index)}

--- a/src/routes/graph-editor/+page.svelte
+++ b/src/routes/graph-editor/+page.svelte
@@ -5,7 +5,9 @@
 	// Components
 	import { page } from '$app/state';
 	import Help from '$lib/components/Help.svelte';
-	import { Button } from '$lib/components/ui/button';
+	import { buttonVariants } from '$lib/components/ui/button';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { cn } from '$lib/utils';
 	import { Archive, ArchiveX } from '@lucide/svelte';
 	import { untrack } from 'svelte';
 	import PinnedCourses from './PinnedCourses.svelte';
@@ -59,19 +61,27 @@
 				<SearchCourses {courses} />
 
 				{#if data.programs.length && courses.some((course) => course.isArchived)}
-					<Button
-						variant="outline"
-						class="border-2 p-3"
-						onclick={() => {
-							showArchivedCourses = !showArchivedCourses;
-						}}
-					>
-						{#if showArchivedCourses}
-							<ArchiveX />
-						{:else}
-							<Archive />
-						{/if}
-					</Button>
+					<Tooltip.Provider>
+						<Tooltip.Root>
+							<Tooltip.Trigger
+								class={cn(buttonVariants({ variant: 'outline' }), 'border-2 p-3')}
+								onclick={() => {
+									showArchivedCourses = !showArchivedCourses;
+								}}
+							>
+								{#if showArchivedCourses}
+									<ArchiveX />
+								{:else}
+									<Archive />
+								{/if}
+							</Tooltip.Trigger>
+							<Tooltip.Content
+								><p>
+									{showArchivedCourses ? 'Hide archived courses' : 'Show archived courses'}
+								</p></Tooltip.Content
+							>
+						</Tooltip.Root>
+					</Tooltip.Provider>
 				{/if}
 			{/await}
 		</div>

--- a/src/routes/graph-editor/CourseGrid.svelte
+++ b/src/routes/graph-editor/CourseGrid.svelte
@@ -5,6 +5,7 @@
 
 	// Components
 	import { Button } from '$lib/components/ui/button';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 
 	// Icons
 	import { Settings } from '@lucide/svelte';
@@ -51,14 +52,24 @@
 
 		<div class="flex items-center gap-1">
 			{#if course.isArchived}
-				<Button
-					variant="outline"
-					href={resolve('/graph-editor/courses/[courseCode]/settings', {
-						courseCode: course.uriCode
-					})}
-				>
-					<Settings class="text-gray-600" />
-				</Button>
+				<Tooltip.Provider>
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button
+									{...props}
+									variant="outline"
+									href={resolve('/graph-editor/courses/[courseCode]/settings', {
+										courseCode: course.uriCode
+									})}
+								>
+									<Settings class="text-gray-600" />
+								</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content><p>Course settings</p></Tooltip.Content>
+					</Tooltip.Root>
+				</Tooltip.Provider>
 			{/if}
 
 			{#if user}

--- a/src/routes/graph-editor/PinUnpin.svelte
+++ b/src/routes/graph-editor/PinUnpin.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import * as Form from '$lib/components/ui/form/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { changePinSchema } from '$lib/zod/courseSchema';
 	import type { Course, User } from '@prisma/client';
 	import { useId } from 'bits-ui';
@@ -43,25 +44,35 @@
 	<input type="text" name="courseId" value={course.id} hidden />
 	<input type="text" name="pin" value={!pinned} hidden />
 
-	<Form.FormButton
-		variant={pinned ? 'default' : 'outline'}
-		disabled={$submitting}
-		loading={$delayed}
-		onclick={(e) => {
-			e.stopPropagation();
-		}}
-		onsubmit={(e) => {
-			e.stopPropagation();
-		}}
-	>
-		{#if !pinned}
-			<Pin class="text-gray-600" />
-		{:else}
-			<Unpin class="text-white" />
-		{/if}
+	<Tooltip.Provider>
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Form.FormButton
+						{...props}
+						variant={pinned ? 'default' : 'outline'}
+						disabled={$submitting}
+						loading={$delayed}
+						onclick={(e) => {
+							e.stopPropagation();
+						}}
+						onsubmit={(e) => {
+							e.stopPropagation();
+						}}
+					>
+						{#if !pinned}
+							<Pin class="text-gray-600" />
+						{:else}
+							<Unpin class="text-white" />
+						{/if}
 
-		{#snippet loadingMessage()}
-			<Loader class={cn('animate-spin', pinned ? 'text-gray-300' : 'text-gray-600')} />
-		{/snippet}
-	</Form.FormButton>
+						{#snippet loadingMessage()}
+							<Loader class={cn('animate-spin', pinned ? 'text-gray-300' : 'text-gray-600')} />
+						{/snippet}
+					</Form.FormButton>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content><p>{pinned ? 'Unpin course' : 'Pin course'}</p></Tooltip.Content>
+		</Tooltip.Root>
+	</Tooltip.Provider>
 </form>

--- a/src/routes/graph-editor/Program.svelte
+++ b/src/routes/graph-editor/Program.svelte
@@ -11,6 +11,7 @@
 	import AddCourse from '$lib/components/addCourse/AddCourse.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Table from '$lib/components/ui/table/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import CourseGrid from './CourseGrid.svelte';
 
 	// Icons
@@ -94,11 +95,21 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={user.id == admin.id}
-								variant="outline"
-								href={generateMailToLink(admin, program)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={user.id == admin.id}
+												variant="outline"
+												href={generateMailToLink(admin, program)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email admin</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}
@@ -110,11 +121,21 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={user.id == editor.id}
-								variant="outline"
-								href={generateMailToLink(editor, program)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={user.id == editor.id}
+												variant="outline"
+												href={generateMailToLink(editor, program)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email editor</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}

--- a/src/routes/graph-editor/Program.svelte
+++ b/src/routes/graph-editor/Program.svelte
@@ -95,7 +95,7 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}
@@ -121,7 +121,7 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}

--- a/src/routes/graph-editor/SearchCourses.svelte
+++ b/src/routes/graph-editor/SearchCourses.svelte
@@ -7,6 +7,7 @@
 	// Components
 	import { Button } from '$lib/components/ui/button';
 	import * as Command from '$lib/components/ui/command/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 
 	// Icons
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
@@ -30,17 +31,27 @@
 
 	{#if courseValue}
 		<div class="absolute top-1/2 right-0 h-fit w-fit -translate-y-1/2" in:fade>
-			<Button
-				onclick={(e) => {
-					e.preventDefault();
-					e.stopPropagation();
-					courseValue = '';
-				}}
-				class="size-8 p-0"
-				variant="ghost"
-			>
-				<Close class="size-3" />
-			</Button>
+			<Tooltip.Provider>
+				<Tooltip.Root>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Button
+								{...props}
+								onclick={(e) => {
+									e.preventDefault();
+									e.stopPropagation();
+									courseValue = '';
+								}}
+								class="size-8 p-0"
+								variant="ghost"
+							>
+								<Close class="size-3" />
+							</Button>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content><p>Clear search</p></Tooltip.Content>
+				</Tooltip.Root>
+			</Tooltip.Provider>
 		</div>
 		<Command.List
 			class="absolute top-10 left-0 max-h-96 w-full rounded-lg border-2 border-gray-200 bg-white shadow-lg"

--- a/src/routes/graph-editor/courses/+page.svelte
+++ b/src/routes/graph-editor/courses/+page.svelte
@@ -192,7 +192,7 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}
@@ -218,7 +218,7 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}
@@ -266,7 +266,7 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}
@@ -292,7 +292,7 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}

--- a/src/routes/graph-editor/courses/+page.svelte
+++ b/src/routes/graph-editor/courses/+page.svelte
@@ -9,6 +9,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { displayName } from '$lib/utils/displayUserName';
 	import * as Table from '$lib/components/ui/table/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import SearchCourses from '../SearchCourses.svelte';
 	import CourseGrid from '../CourseGrid.svelte';
 
@@ -191,11 +192,21 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={data.user?.id == user.id}
-								variant="outline"
-								href={generateMailToLink(user, course)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={data.user?.id == user.id}
+												variant="outline"
+												href={generateMailToLink(user, course)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email user</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}
@@ -207,11 +218,21 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={data.user?.id == user.id}
-								variant="outline"
-								href={generateMailToLink(user, course)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={data.user?.id == user.id}
+												variant="outline"
+												href={generateMailToLink(user, course)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email user</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}
@@ -245,11 +266,21 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={data.user?.id == user.id}
-								variant="outline"
-								href={generateMailToLink(user, course)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={data.user?.id == user.id}
+												variant="outline"
+												href={generateMailToLink(user, course)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email user</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}
@@ -261,11 +292,21 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={data.user?.id == user.id}
-								variant="outline"
-								href={generateMailToLink(user, course)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={data.user?.id == user.id}
+												variant="outline"
+												href={generateMailToLink(user, course)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email user</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}

--- a/src/routes/graph-editor/courses/[courseCode]/ShowAdmins.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/ShowAdmins.svelte
@@ -53,7 +53,7 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}
@@ -79,7 +79,7 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}
@@ -127,7 +127,7 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}
@@ -155,7 +155,7 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Tooltip.Provider>
+							<Tooltip.Provider ignoreNonKeyboardFocus>
 								<Tooltip.Root>
 									<Tooltip.Trigger>
 										{#snippet child({ props })}

--- a/src/routes/graph-editor/courses/[courseCode]/ShowAdmins.svelte
+++ b/src/routes/graph-editor/courses/[courseCode]/ShowAdmins.svelte
@@ -4,6 +4,7 @@
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { displayName } from '$lib/utils/displayUserName';
 	import { Button } from '$lib/components/ui/button';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { MailOpen } from '@lucide/svelte';
 
 	type ShowAdminsProps = {
@@ -52,11 +53,21 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={user.id == admin.id}
-								variant="outline"
-								href={generateMailToLink(admin, course)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={user.id == admin.id}
+												variant="outline"
+												href={generateMailToLink(admin, course)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email admin</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}
@@ -68,11 +79,21 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={user.id == editor.id}
-								variant="outline"
-								href={generateMailToLink(editor, course)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={user.id == editor.id}
+												variant="outline"
+												href={generateMailToLink(editor, course)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email editor</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}
@@ -106,11 +127,21 @@
 						</Table.Cell>
 						<Table.Cell class="text-left">Admin</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={user.id == admin.id}
-								variant="outline"
-								href={generateMailToLink(admin, course)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={user.id == admin.id}
+												variant="outline"
+												href={generateMailToLink(admin, course)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email admin</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}
@@ -124,11 +155,21 @@
 						</Table.Cell>
 						<Table.Cell>Editor</Table.Cell>
 						<Table.Cell class="text-right">
-							<Button
-								disabled={user.id == editor.id}
-								variant="outline"
-								href={generateMailToLink(editor, course)}><MailOpen /></Button
-							>
+							<Tooltip.Provider>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										{#snippet child({ props })}
+											<Button
+												{...props}
+												disabled={user.id == editor.id}
+												variant="outline"
+												href={generateMailToLink(editor, course)}><MailOpen /></Button
+											>
+										{/snippet}
+									</Tooltip.Trigger>
+									<Tooltip.Content><p>Email editor</p></Tooltip.Content>
+								</Tooltip.Root>
+							</Tooltip.Provider>
 						</Table.Cell>
 					</Table.Row>
 				{/each}

--- a/src/routes/graph-editor/graphs/[graphid=int]/IssueIndicator.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/IssueIndicator.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as Popover from '$lib/components/ui/popover/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { TriangleAlert, CircleAlert } from '@lucide/svelte';
 	import type { Issue } from '$lib/validators/types';
 
@@ -15,19 +16,32 @@
 
 {#if severity !== 'none'}
 	<Popover.Root>
-		{#if severity === 'error'}
-			<Popover.Trigger
-				class="cursor-pointer rounded bg-red-300/35 p-1 text-red-900 transition-colors hover:bg-red-300"
-			>
-				<TriangleAlert />
-			</Popover.Trigger>
-		{:else if severity === 'warning'}
-			<Popover.Trigger
-				class="cursor-pointer rounded bg-yellow-300/35 p-1 text-yellow-900 transition-colors hover:bg-yellow-300"
-			>
-				<CircleAlert />
-			</Popover.Trigger>
-		{/if}
+		<Tooltip.Provider>
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						{#if severity === 'error'}
+							<Popover.Trigger
+								{...props}
+								class="cursor-pointer rounded bg-red-300/35 p-1 text-red-900 transition-colors hover:bg-red-300"
+							>
+								<TriangleAlert />
+							</Popover.Trigger>
+						{:else if severity === 'warning'}
+							<Popover.Trigger
+								{...props}
+								class="cursor-pointer rounded bg-yellow-300/35 p-1 text-yellow-900 transition-colors hover:bg-yellow-300"
+							>
+								<CircleAlert />
+							</Popover.Trigger>
+						{/if}
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content
+					><p>{severity === 'error' ? 'View errors' : 'View warnings'}</p></Tooltip.Content
+				>
+			</Tooltip.Root>
+		</Tooltip.Provider>
 
 		<Popover.Content side="right" class="divide-y divide-gray-200 px-4 py-0">
 			{#each issues as issue (issue.id)}

--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomain.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/ChangeDomain.svelte
@@ -16,6 +16,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import * as Menubar from '$lib/components/ui/menubar/index.js';
 	import * as Popover from '$lib/components/ui/popover/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import * as RadioGroup from '$lib/components/ui/radio-group/index.js';
 
 	import ChevronDown from '@lucide/svelte/icons/chevron-down';
@@ -72,9 +73,21 @@
 
 <Menubar.Root class="ml-auto max-w-10 p-0">
 	<Menubar.Menu value="menu">
-		<Menubar.Trigger class={cn(buttonVariants({ variant: 'outline', size: 'icon' }))}>
-			<Ellipsis class="size-4 w-full" />
-		</Menubar.Trigger>
+		<Tooltip.Provider>
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Menubar.Trigger
+							{...props}
+							class={cn(buttonVariants({ variant: 'outline', size: 'icon' }))}
+						>
+							<Ellipsis class="size-4 w-full" />
+						</Menubar.Trigger>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content><p>Domain options</p></Tooltip.Content>
+			</Tooltip.Root>
+		</Tooltip.Provider>
 		<Menubar.Content>
 			<Menubar.Item class="p-0">
 				<DialogButton

--- a/src/routes/graph-editor/graphs/[graphid=int]/domains/DeleteDomainRel.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/domains/DeleteDomainRel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as Form from '$lib/components/ui/form/index.js';
 	import * as Popover from '$lib/components/ui/popover/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 
 	import { page } from '$app/state';
 	import { buttonVariants } from '$lib/components/ui/button';
@@ -45,9 +46,18 @@
 </script>
 
 <Popover.Root>
-	<Popover.Trigger class={cn(buttonVariants({ variant: 'destructive' }))}>
-		<Trash2 />
-	</Popover.Trigger>
+	<Tooltip.Provider>
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Popover.Trigger {...props} class={cn(buttonVariants({ variant: 'destructive' }))}>
+						<Trash2 />
+					</Popover.Trigger>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content><p>Delete relationship</p></Tooltip.Content>
+		</Tooltip.Root>
+	</Tooltip.Provider>
 	<Popover.Content side="right" class="space-y-1">
 		<form action="?/delete-domain-rel" method="POST" use:enhance>
 			<input type="hidden" name="graphId" value={graph.id} />

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubject.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/ChangeSubject.svelte
@@ -7,6 +7,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import * as Menubar from '$lib/components/ui/menubar/index.js';
 	import * as Popover from '$lib/components/ui/popover/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { closeAndFocusTrigger, cn } from '$lib/utils';
 	import type { PrismaGraphPayload } from '$lib/validators/types';
 	import { subjectSchema } from '$lib/zod/subjectSchema';
@@ -61,9 +62,18 @@
 
 <Menubar.Root class="interactive ml-auto max-w-10 p-0">
 	<Menubar.Menu value="menu">
-		<Menubar.Trigger class="h-full w-full">
-			<Ellipsis class="size-4 w-full" />
-		</Menubar.Trigger>
+		<Tooltip.Provider>
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Menubar.Trigger {...props} class="h-full w-full">
+							<Ellipsis class="size-4 w-full" />
+						</Menubar.Trigger>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content><p>Subject options</p></Tooltip.Content>
+			</Tooltip.Root>
+		</Tooltip.Provider>
 		<Menubar.Content>
 			<Menubar.Item class="p-0">
 				<DialogButton

--- a/src/routes/graph-editor/graphs/[graphid=int]/subjects/DeleteSubjectRel.svelte
+++ b/src/routes/graph-editor/graphs/[graphid=int]/subjects/DeleteSubjectRel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as Form from '$lib/components/ui/form/index.js';
 	import * as Popover from '$lib/components/ui/popover/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 
 	import { page } from '$app/state';
 	import { buttonVariants } from '$lib/components/ui/button';
@@ -46,9 +47,18 @@
 </script>
 
 <Popover.Root>
-	<Popover.Trigger class={cn(buttonVariants({ variant: 'destructive' }))}>
-		<Trash2 />
-	</Popover.Trigger>
+	<Tooltip.Provider>
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Popover.Trigger {...props} class={cn(buttonVariants({ variant: 'destructive' }))}>
+						<Trash2 />
+					</Popover.Trigger>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content><p>Delete relationship</p></Tooltip.Content>
+		</Tooltip.Root>
+	</Tooltip.Provider>
 	<Popover.Content side="right" class="space-y-1">
 		<form action="?/delete-subject-rel" method="POST" use:enhance>
 			<input type="hidden" name="graphId" value={graph.id} />


### PR DESCRIPTION
## Summary
- Wraps icon-only buttons across the app with the existing sidebar `Tooltip` component (`Tooltip.Provider`/`Root`/`Trigger`/`Content`) so their action is discoverable on hover and keyboard focus
- Covers graph canvas controls (center, zoom in/out, fullscreen toggle), delete-relationship buttons, domain/subject options menus, pin/unpin, archived-course settings link, email admin/editor links, show/hide archived courses toggle, search clear button
- Left untouched: buttons that already carry visible text, and the domain/subject color-swatch popover triggers (not icon components)

Closes #53