### PR TITLE
Consistent 404 handling for missing graphs

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { page } from '$app/state';
+
+	const statusMessages: Record<number, string> = {
+		404: 'Page not found',
+		403: "You don't have access to this page",
+		500: 'Something went wrong'
+	};
+
+	let title = $derived(statusMessages[page.status] ?? 'Something went wrong');
+	let message = $derived(page.error?.message || 'Please check the URL and try again.');
+</script>
+
+<svelte:head>
+	<title>{title} | PRIME Graph Editor</title>
+</svelte:head>
+
+<div
+	class="flex h-[calc(100dvh)] w-full items-center justify-center rounded-lg bg-purple-200/50 p-2"
+>
+	<div class="max-w-md space-y-3 text-center">
+		<p class="text-sm font-medium text-purple-700">{page.status}</p>
+		<h1 class="text-2xl font-semibold text-gray-900">{title}</h1>
+		<p class="text-gray-600">{message}</p>
+	</div>
+</div>

--- a/src/routes/graph-editor/graphs/[graphid=int]/+layout.server.ts
+++ b/src/routes/graph-editor/graphs/[graphid=int]/+layout.server.ts
@@ -1,7 +1,7 @@
 import prisma from '$lib/server/db/prisma';
 import { GraphValidator } from '$lib/validators/graphValidator';
 import type { Breadcrumb } from '$lib/utils/breadcrumbs';
-import { error } from '@sveltejs/kit';
+import { error, redirect, isRedirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 
 const leafLabels: Record<string, string> = {
@@ -59,7 +59,7 @@ export const load: LayoutServerLoad = async ({ params, url }) => {
 			}
 		});
 
-		if (!graph) error(404, { message: 'Graph not found' });
+		if (!graph) redirect(303, '/graph-editor?error=Graph not found');
 
 		const graphValidator = new GraphValidator(graph);
 		const issues = graphValidator.validate();
@@ -94,6 +94,7 @@ export const load: LayoutServerLoad = async ({ params, url }) => {
 			breadcrumbs
 		};
 	} catch (e: unknown) {
+		if (isRedirect(e)) throw e;
 		error(500, { message: e instanceof Error ? e.message : `${e}` });
 	}
 };

--- a/src/routes/graph/[code]/[alias]/+error.svelte
+++ b/src/routes/graph/[code]/[alias]/+error.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { page } from '$app/state';
+
+	const statusMessages: Record<number, string> = {
+		404: "This graph isn't available",
+		400: 'Invalid graph link',
+		500: 'Something went wrong'
+	};
+
+	let title = $derived(statusMessages[page.status] ?? 'Something went wrong');
+	let message = $derived(page.error?.message || 'This graph could not be loaded.');
+</script>
+
+<svelte:head>
+	<title>{title} | PRIME Graph Editor</title>
+</svelte:head>
+
+<div
+	class="flex h-[calc(100dvh)] w-full items-center justify-center rounded-lg bg-purple-200/50 p-2"
+>
+	<div class="max-w-md space-y-3 text-center">
+		<p class="text-sm font-medium text-purple-700">{page.status}</p>
+		<h1 class="text-2xl font-semibold text-gray-900">{title}</h1>
+		<p class="text-gray-600">{message}</p>
+		<p class="text-sm text-gray-500">Ask your course staff or lecturer for the correct link.</p>
+	</div>
+</div>

--- a/src/routes/graph/[code]/[alias]/+page.server.ts
+++ b/src/routes/graph/[code]/[alias]/+page.server.ts
@@ -1,5 +1,5 @@
 import prisma from '$lib/server/db/prisma';
-import { error, type ServerLoad } from '@sveltejs/kit';
+import { error, isHttpError, type ServerLoad } from '@sveltejs/kit';
 
 export const load: ServerLoad = async ({ params }) => {
 	const courseCode = params.code;
@@ -9,8 +9,9 @@ export const load: ServerLoad = async ({ params }) => {
 		throw new Error('Course code and alias are required');
 	}
 
+	let graph;
 	try {
-		const graph = await prisma.graph.findFirst({
+		graph = await prisma.graph.findFirst({
 			where: {
 				course: {
 					uriCode: encodeURIComponent(courseCode)
@@ -48,14 +49,15 @@ export const load: ServerLoad = async ({ params }) => {
 				}
 			}
 		});
-
-		if (!graph) error(404, { message: 'Graph not found' });
-
-		// Happy path
-		return {
-			graph: graph
-		};
 	} catch (e: unknown) {
+		if (isHttpError(e)) throw e;
 		error(500, { message: e instanceof Error ? e.message : `${e}` });
 	}
+
+	if (!graph) error(404, { message: 'Graph not found' });
+
+	// Happy path
+	return {
+		graph: graph
+	};
 };


### PR DESCRIPTION
Closes #93

## Summary
- Graph editor: missing graph now redirects to `/graph-editor?error=Graph not found`, matching existing course/sandbox not-found toast pattern. 400 (invalid id) and 500 (unexpected error) paths untouched.
- Public graph viewer: added `+error.svelte` route boundary at `/graph/[code]/[alias]` rendering a branded, status-aware not-found page (works for any error status thrown while resolving the graph, not just 404). Shows a hint to contact course staff/lecturer, no navigation links elsewhere in the app per issue scope.

## Test plan
- [x] `pnpm check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Manually verify: bad graph id in editor redirects with toast
- [x] Manually verify: bad code/alias on public viewer shows new error page