### PR TITLE
Build integration test infra for pnpm test:integration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   formatting:
     runs-on: ubuntu-latest
@@ -135,6 +138,9 @@ jobs:
 
       - name: Push prisma schema to test database
         run: pnpm prisma db push
+
+      - name: Generate svelte-kit types
+        run: pnpm svelte-kit sync
 
       - name: Run integration tests
         run: npx vitest run -c ./vitest.config.integration.ts

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -90,3 +90,51 @@ jobs:
 
       - name: Run tests
         run: pnpm test:unit
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    services:
+      db-test:
+        image: postgres:16
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: local
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U testuser -d local"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://testuser:testpassword@localhost:5433/local
+      DEBUG: 'false'
+      TESTING: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Generate prisma schema
+        run: pnpm prisma generate
+
+      - name: Push prisma schema to test database
+        run: pnpm prisma db push
+
+      - name: Run integration tests
+        run: npx vitest run -c ./vitest.config.integration.ts

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ NETLIFY_CONTEXT=DEPLOY_PREVIEW pnpm run dev
 pnpm test:integration
 ```
 
+Spins up a `db-test` service (via podman/docker compose), pushes the Prisma schema, seeds
+the fixture below, then runs `src/lib/server/actions/tests/**/*.test.ts` against it. Runs
+in CI on every push and pull request (`.github/workflows/check.yml`, `integration-tests` job)
+against a Postgres service container instead of compose.
+
 ```mermaid
 flowchart LR;
 	TEST_DB[(Test Database)]

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,7 +30,21 @@ services:
     healthcheck:
       test: pg_isready -d ${POSTGRES_DB} -U ${POSTGRES_USER}
 
+  db-test:
+    image: docker.io/postgres:16
+    ports:
+      - '5433:5432'
+    volumes:
+      - postgres_test_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: testuser
+      POSTGRES_PASSWORD: testpassword
+      POSTGRES_DB: local
+    healthcheck:
+      test: pg_isready -d local -U testuser
+
 volumes:
   postgres_data:
+  postgres_test_data:
   caddy_data:
   caddy_config:

--- a/scripts/run-integration.sh
+++ b/scripts/run-integration.sh
@@ -27,6 +27,7 @@ fi
 
 pnpm prisma generate
 pnpm prisma db push
+pnpm svelte-kit sync
 
 if [ "$#" -eq  "0" ]
   then

--- a/src/lib/server/actions/tests/helpers/env.ts
+++ b/src/lib/server/actions/tests/helpers/env.ts
@@ -1,0 +1,4 @@
+// Stands in for SvelteKit's `$env/dynamic/private` module (aliased in vitest.config.integration.ts),
+// since the integration suite runs outside the SvelteKit Vite plugin. Values come from .env.test,
+// exported into the process environment by scripts/setenv.sh before vitest starts.
+export const env = process.env;

--- a/src/lib/server/actions/tests/helpers/fixture.ts
+++ b/src/lib/server/actions/tests/helpers/fixture.ts
@@ -1,0 +1,158 @@
+import prisma from '$lib/server/db/prisma';
+
+// See the "Testing" section of README.md for the fixture diagram this mirrors.
+
+export const FIXTURE_EMAILS = {
+	superAdmin: 'super-admin@fixture.test',
+	programAdmin: 'program-admin@fixture.test',
+	programEditor: 'program-editor@fixture.test',
+	courseAdmin: 'course-admin@fixture.test',
+	courseEditor: 'course-editor@fixture.test'
+} as const;
+
+export const FIXTURE_PROGRAMS = {
+	one: 'ProgramOne',
+	two: 'ProgramTwo',
+	three: 'ProgramThree'
+} as const;
+
+export const FIXTURE_COURSES = {
+	one: { code: 'FIXTURE-1', uriCode: 'fixture-course-one', name: 'CourseOne' },
+	two: { code: 'FIXTURE-2', uriCode: 'fixture-course-two', name: 'CourseTwo' },
+	three: { code: 'FIXTURE-3', uriCode: 'fixture-course-three', name: 'CourseThree' }
+} as const;
+
+export const FIXTURE_GRAPHS = {
+	one: 'GraphOne',
+	two: 'GraphTwo',
+	three: 'GraphThree'
+} as const;
+
+async function resetDatabase() {
+	await prisma.$transaction([
+		prisma.link.deleteMany(),
+		prisma.lecture.deleteMany(),
+		prisma.subject.deleteMany(),
+		prisma.domain.deleteMany(),
+		prisma.graph.deleteMany(),
+		prisma.sandbox.deleteMany(),
+		prisma.course.deleteMany(),
+		prisma.program.deleteMany(),
+		prisma.user.deleteMany()
+	]);
+}
+
+// Seeds GraphOne's content (or a copy of it, for GraphTwo/GraphThree) onto the given graph:
+// DomainOne -> DomainTwo -> DomainThree, SubjectThree -> SubjectTwo -> SubjectOne,
+// with SubjectOne & SubjectTwo mapped to DomainOne, and SubjectThree mapped to DomainTwo.
+async function seedGraphContent(graphId: number) {
+	const domainOne = await prisma.domain.create({ data: { name: 'DomainOne', order: 0, graphId } });
+	const domainTwo = await prisma.domain.create({ data: { name: 'DomainTwo', order: 1, graphId } });
+	const domainThree = await prisma.domain.create({
+		data: { name: 'DomainThree', order: 2, graphId }
+	});
+
+	await prisma.domain.update({
+		where: { id: domainOne.id },
+		data: { targetDomains: { connect: { id: domainTwo.id } } }
+	});
+	await prisma.domain.update({
+		where: { id: domainTwo.id },
+		data: {
+			sourceDomains: { connect: { id: domainOne.id } },
+			targetDomains: { connect: { id: domainThree.id } }
+		}
+	});
+	await prisma.domain.update({
+		where: { id: domainThree.id },
+		data: { sourceDomains: { connect: { id: domainTwo.id } } }
+	});
+
+	const subjectOne = await prisma.subject.create({
+		data: { name: 'SubjectOne', order: 0, graphId, domainId: domainOne.id }
+	});
+	const subjectTwo = await prisma.subject.create({
+		data: { name: 'SubjectTwo', order: 1, graphId, domainId: domainOne.id }
+	});
+	const subjectThree = await prisma.subject.create({
+		data: { name: 'SubjectThree', order: 2, graphId, domainId: domainTwo.id }
+	});
+
+	await prisma.subject.update({
+		where: { id: subjectThree.id },
+		data: { targetSubjects: { connect: { id: subjectTwo.id } } }
+	});
+	await prisma.subject.update({
+		where: { id: subjectTwo.id },
+		data: {
+			sourceSubjects: { connect: { id: subjectThree.id } },
+			targetSubjects: { connect: { id: subjectOne.id } }
+		}
+	});
+	await prisma.subject.update({
+		where: { id: subjectOne.id },
+		data: { sourceSubjects: { connect: { id: subjectTwo.id } } }
+	});
+}
+
+/**
+ * Wipes the test database and reseeds it with the fixture documented in README.md's Testing
+ * section: three programs, each linked to three courses, with CourseOne/Two/Three owning
+ * GraphOne/Two/Three (identical content, copied not shared).
+ */
+export async function seedFixture() {
+	await resetDatabase();
+
+	const [, programAdmin, programEditor, courseAdmin, courseEditor] = await Promise.all([
+		prisma.user.create({
+			data: { role: 'ADMIN', email: FIXTURE_EMAILS.superAdmin, nickname: 'Super Admin' }
+		}),
+		prisma.user.create({ data: { email: FIXTURE_EMAILS.programAdmin, nickname: 'Program Admin' } }),
+		prisma.user.create({
+			data: { email: FIXTURE_EMAILS.programEditor, nickname: 'Program Editor' }
+		}),
+		prisma.user.create({ data: { email: FIXTURE_EMAILS.courseAdmin, nickname: 'Course Admin' } }),
+		prisma.user.create({ data: { email: FIXTURE_EMAILS.courseEditor, nickname: 'Course Editor' } })
+	]);
+
+	const courseOne = await prisma.course.create({ data: FIXTURE_COURSES.one });
+	const courseTwo = await prisma.course.create({
+		data: { ...FIXTURE_COURSES.two, admins: { connect: { id: courseAdmin.id } } }
+	});
+	const courseThree = await prisma.course.create({
+		data: { ...FIXTURE_COURSES.three, editors: { connect: { id: courseEditor.id } } }
+	});
+	const allCourses = {
+		connect: [{ id: courseOne.id }, { id: courseTwo.id }, { id: courseThree.id }]
+	};
+
+	await prisma.program.create({ data: { name: FIXTURE_PROGRAMS.one, courses: allCourses } });
+	await prisma.program.create({
+		data: {
+			name: FIXTURE_PROGRAMS.two,
+			admins: { connect: { id: programAdmin.id } },
+			courses: allCourses
+		}
+	});
+	await prisma.program.create({
+		data: {
+			name: FIXTURE_PROGRAMS.three,
+			editors: { connect: { id: programEditor.id } },
+			courses: allCourses
+		}
+	});
+
+	const graphOne = await prisma.graph.create({
+		data: { name: FIXTURE_GRAPHS.one, parentType: 'COURSE', courseId: courseOne.id }
+	});
+	const graphTwo = await prisma.graph.create({
+		data: { name: FIXTURE_GRAPHS.two, parentType: 'COURSE', courseId: courseTwo.id }
+	});
+	const graphThree = await prisma.graph.create({
+		data: { name: FIXTURE_GRAPHS.three, parentType: 'COURSE', courseId: courseThree.id }
+	});
+
+	await seedGraphContent(graphOne.id);
+	await seedGraphContent(graphTwo.id);
+	await seedGraphContent(graphThree.id);
+}

--- a/src/lib/server/actions/tests/helpers/setup.ts
+++ b/src/lib/server/actions/tests/helpers/setup.ts
@@ -1,0 +1,9 @@
+import { beforeAll } from 'vitest';
+import { seedFixture } from './fixture';
+
+// Runs once per test file (vitest applies setupFiles per file). fileParallelism is off in
+// vitest.config.integration.ts, so files run one after another and each reseeds the fixture
+// from scratch before its own tests run.
+beforeAll(async () => {
+	await seedFixture();
+});

--- a/src/lib/server/actions/tests/smoke.test.ts
+++ b/src/lib/server/actions/tests/smoke.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import prisma from '$lib/server/db/prisma';
+import { FIXTURE_COURSES, FIXTURE_GRAPHS, FIXTURE_PROGRAMS } from './helpers/fixture';
+
+describe('integration test harness', () => {
+	it('loads the seeded fixture', async () => {
+		const programs = await prisma.program.findMany({ include: { courses: true } });
+		expect(programs.map((p) => p.name).sort()).toEqual(
+			[FIXTURE_PROGRAMS.one, FIXTURE_PROGRAMS.two, FIXTURE_PROGRAMS.three].sort()
+		);
+		for (const program of programs) {
+			expect(program.courses).toHaveLength(3);
+		}
+
+		const graphOne = await prisma.graph.findFirstOrThrow({
+			where: { name: FIXTURE_GRAPHS.one, course: { code: FIXTURE_COURSES.one.code } },
+			include: { domains: { include: { targetDomains: true } }, subjects: true }
+		});
+		expect(graphOne.domains).toHaveLength(3);
+		expect(graphOne.subjects).toHaveLength(3);
+
+		const domainOne = graphOne.domains.find((d) => d.name === 'DomainOne');
+		expect(domainOne?.targetDomains.map((d) => d.name)).toEqual(['DomainTwo']);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a `db-test` compose service (root `compose.yaml`) matching `.env.test`'s connection details (`testuser`/`testpassword`/`local` on port 5433), with its own volume so integration runs never touch dev data
- Adds `helpers/env.ts`, satisfying the `$env/dynamic/private` alias `vitest.config.integration.ts` wires up
- Adds `helpers/fixture.ts` + `helpers/setup.ts`, seeding the fixture documented in README.md's Testing section (three programs/courses with role m2m relations, GraphOne/Two/Three as identical copies with domain/subject relations) before each integration test file runs
- Adds a smoke test proving the harness loads the fixture end to end

## Test plan
- [x] `pnpm test:integration` runs to completion against a real Postgres instance
- [x] `pnpm lint`
- [x] `pnpm check`
- [x] `pnpm test` (unit)

Closes #127