### PR TITLE
fix: leftover 404 gaps from #137

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { page } from '$app/state';
+
+	const statusMessages: Record<number, string> = {
+		404: 'Page not found',
+		403: "You don't have access to this page",
+		500: 'Something went wrong'
+	};
+
+	let title = $derived(statusMessages[page.status] ?? 'Something went wrong');
+	let message = $derived(page.error?.message || 'Please check the URL and try again.');
+</script>
+
+<svelte:head>
+	<title>{title} | PRIME Graph Editor</title>
+</svelte:head>
+
+<div
+	class="flex h-[calc(100dvh)] w-full items-center justify-center rounded-lg bg-purple-200/50 p-2"
+>
+	<div class="max-w-md space-y-3 text-center">
+		<p class="text-sm font-medium text-purple-700">{page.status}</p>
+		<h1 class="text-2xl font-semibold text-gray-900">{title}</h1>
+		<p class="text-gray-600">{message}</p>
+	</div>
+</div>

--- a/src/routes/graph/[code]/[alias]/+page.server.ts
+++ b/src/routes/graph/[code]/[alias]/+page.server.ts
@@ -1,5 +1,5 @@
 import prisma from '$lib/server/db/prisma';
-import { error, type ServerLoad } from '@sveltejs/kit';
+import { error, isHttpError, type ServerLoad } from '@sveltejs/kit';
 
 export const load: ServerLoad = async ({ params }) => {
 	const courseCode = params.code;
@@ -9,8 +9,9 @@ export const load: ServerLoad = async ({ params }) => {
 		throw new Error('Course code and alias are required');
 	}
 
+	let graph;
 	try {
-		const graph = await prisma.graph.findFirst({
+		graph = await prisma.graph.findFirst({
 			where: {
 				course: {
 					uriCode: encodeURIComponent(courseCode)
@@ -48,14 +49,15 @@ export const load: ServerLoad = async ({ params }) => {
 				}
 			}
 		});
-
-		if (!graph) error(404, { message: 'Graph not found' });
-
-		// Happy path
-		return {
-			graph: graph
-		};
 	} catch (e: unknown) {
+		if (isHttpError(e)) throw e;
 		error(500, { message: e instanceof Error ? e.message : `${e}` });
 	}
+
+	if (!graph) error(404, { message: 'Graph not found' });
+
+	// Happy path
+	return {
+		graph: graph
+	};
 };


### PR DESCRIPTION
Follow-up to #137 / #93.

## Problem
- Unmatched routes (e.g. `/dasdas`, `/graph-editor/graphs/6/afsasdd`) had no root `+error.svelte`, so they hit SvelteKit's raw "404 page not found" text.
- Public graph viewer (`/graph/[code]/[alias]`) returned 500 instead of 404 for a missing graph: `error(404, ...)` was thrown inside a `try` block, caught by its own `catch`, and re-wrapped as `error(500, ...)`.

## Fix
- Added root `src/routes/+error.svelte`, styled like the existing public graph error page, for any unmatched or unhandled route.
- Moved the not-found check out of the try block in `graph/[code]/[alias]/+page.server.ts` and rethrow `HttpError` from the catch so real DB failures still map to 500, not-found stays 404.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm check` (no new errors introduced)
- [x] `pnpm test`
- [ ] Manually verify `/dasdas` and `/graph-editor/graphs/6/afsasdd` show styled 404
- [ ] Manually verify public graph 404 link shows 404, not 500